### PR TITLE
Add automated thumbnail pipeline

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "gray-matter": "^4.0.3",
         "mime-types": "^2.1.35",
         "morgan": "^1.10.0",
+        "sharp": "^0.33.4",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -40,6 +41,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -484,6 +495,367 @@
         "node": ">=18"
       }
     },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -877,6 +1249,47 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -959,6 +1372,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -1405,6 +1827,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1800,6 +2228,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
@@ -1859,6 +2299,45 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1930,6 +2409,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/sprintf-js": {
@@ -2025,7 +2513,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "gray-matter": "^4.0.3",
     "mime-types": "^2.1.35",
     "morgan": "^1.10.0",
+    "sharp": "^0.33.4",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -11,8 +11,12 @@ export const MEDIA_ROOT = process.env.MEDIA_ROOT || path.join(PROJECT_ROOT, 'med
 export const METADATA_ROOT = process.env.METADATA_ROOT || path.join(PROJECT_ROOT, 'storage');
 
 export const FOLDER_META_FILE = path.join(METADATA_ROOT, '.dossier-meta.json');
-export const MEDIA_META_FILE = path.join(METADATA_ROOT, '.media-meta.json');
+export const MEDIA_META_FILE = path.join(MEDIA_ROOT, '.media-meta.json');
 export const SETTINGS_FILE = path.join(METADATA_ROOT, 'settings.json');
+
+export const THUMBNAILS_ROOT = process.env.THUMBNAILS_ROOT || path.join(PROJECT_ROOT, 'thumbnails');
+export const THUMBNAIL_CONFIG_FILE =
+  process.env.THUMBNAIL_CONFIG_FILE || path.join(PROJECT_ROOT, 'config', 'thumbnails.json');
 
 export const CACHE_TTL = Number(process.env.CACHE_TTL ?? 5_000);
 

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -5,6 +5,8 @@ import { metadataStore } from '../services/MetadataStore.js';
 import { fileService } from '../services/FileService.js';
 import { cacheService } from '../services/CacheService.js';
 import { previewService } from '../services/PreviewService.js';
+import { thumbnailService } from '../services/ThumbnailService.js';
+import { thumbnailConfigSchema } from '../types/thumbnails.js';
 
 const router = Router();
 
@@ -207,6 +209,36 @@ router.get('/settings', async (_req, res, next) => {
   try {
     const settings = await metadataStore.readSettings();
     res.json(settings);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/thumbnails', async (_req, res, next) => {
+  try {
+    const summary = await thumbnailService.getSummary();
+    res.json(summary);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/thumbnails', async (req, res, next) => {
+  try {
+    const config = thumbnailConfigSchema.parse(req.body);
+    await thumbnailService.updateConfig(config);
+    cacheService.clear();
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/thumbnails/rebuild', async (_req, res, next) => {
+  try {
+    await thumbnailService.rebuildAll();
+    cacheService.clear();
+    res.json({ success: true });
   } catch (error) {
     next(error);
   }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import morgan from 'morgan';
 import cors from 'cors';
 import apiRouter from './routes/api.js';
 import { metadataStore } from './services/MetadataStore.js';
+import { thumbnailService } from './services/ThumbnailService.js';
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -20,6 +21,7 @@ app.use((err: unknown, _req: express.Request, res: express.Response, _next: expr
 
 export const startServer = async () => {
   await metadataStore.ensureReady();
+  await thumbnailService.ensureReady();
   return app.listen(port, () => {
     console.log(`atelier backend listening on port ${port}`);
   });

--- a/backend/src/services/CacheService.ts
+++ b/backend/src/services/CacheService.ts
@@ -1,5 +1,12 @@
 import chokidar from 'chokidar';
-import { CACHE_TTL, FOLDER_META_FILE, MEDIA_META_FILE, MEDIA_ROOT, SETTINGS_FILE } from '../config.js';
+import {
+  CACHE_TTL,
+  FOLDER_META_FILE,
+  MEDIA_META_FILE,
+  MEDIA_ROOT,
+  SETTINGS_FILE,
+  THUMBNAIL_CONFIG_FILE
+} from '../config.js';
 import { metadataStore } from './MetadataStore.js';
 
 type CacheEntry<T> = {
@@ -12,10 +19,13 @@ export class CacheService {
   private watcher: chokidar.FSWatcher;
 
   constructor() {
-    this.watcher = chokidar.watch([MEDIA_ROOT, FOLDER_META_FILE, MEDIA_META_FILE, SETTINGS_FILE], {
-      ignoreInitial: true,
-      depth: 6
-    });
+    this.watcher = chokidar.watch(
+      [MEDIA_ROOT, FOLDER_META_FILE, MEDIA_META_FILE, SETTINGS_FILE, THUMBNAIL_CONFIG_FILE],
+      {
+        ignoreInitial: true,
+        depth: 6
+      }
+    );
 
     this.watcher.on('all', () => {
       this.clear();

--- a/backend/src/services/MediaLibrary.ts
+++ b/backend/src/services/MediaLibrary.ts
@@ -33,6 +33,10 @@ export interface MediaLeaf extends MediaNodeBase {
   variants?: MediaMetadata['variants'];
   focalPoint?: MediaMetadata['focalPoint'];
   colorPalette?: string[];
+  width?: number;
+  height?: number;
+  orientation?: MediaMetadata['orientation'];
+  thumbnails?: MediaMetadata['thumbnails'];
 }
 
 export type LibraryTree = FolderNode;
@@ -117,7 +121,11 @@ export class MediaLibrary {
           mimeType: mime.lookup(entry.name) || false,
           variants: meta?.variants,
           focalPoint: meta?.focalPoint,
-          colorPalette: meta?.colorPalette
+          colorPalette: meta?.colorPalette,
+          width: meta?.width,
+          height: meta?.height,
+          orientation: meta?.orientation,
+          thumbnails: meta?.thumbnails
         };
         children.push(leaf);
       }

--- a/backend/src/services/MetadataStore.ts
+++ b/backend/src/services/MetadataStore.ts
@@ -43,6 +43,7 @@ export class MetadataStore {
       await fs.writeFile(FOLDER_META_FILE, JSON.stringify({}, null, 2), 'utf-8');
     }
     if (!(await this.exists(MEDIA_META_FILE))) {
+      await fs.mkdir(path.dirname(MEDIA_META_FILE), { recursive: true });
       await fs.writeFile(MEDIA_META_FILE, JSON.stringify({}, null, 2), 'utf-8');
     }
     if (!(await this.exists(SETTINGS_FILE))) {

--- a/backend/src/services/ThumbnailService.ts
+++ b/backend/src/services/ThumbnailService.ts
@@ -1,0 +1,354 @@
+import chokidar from 'chokidar';
+import { promises as fs } from 'fs';
+import path from 'path';
+import sharp, { ResizeOptions } from 'sharp';
+import {
+  MEDIA_ROOT,
+  THUMBNAIL_CONFIG_FILE,
+  THUMBNAILS_ROOT
+} from '../config.js';
+import { metadataStore } from './MetadataStore.js';
+import { relativeMediaPath, toPosix } from '../utils/pathUtils.js';
+import {
+  ThumbnailConfig,
+  resolveOutputFormats,
+  thumbnailConfigSchema,
+  ThumbnailFormat,
+  ThumbnailPreset
+} from '../types/thumbnails.js';
+import { MediaMetadata, MediaThumbnail } from '../types/metadata.js';
+
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif']);
+const DEFAULT_CONFIG: ThumbnailConfig = {
+  formats: {
+    thumb: { width: 320 },
+    medium: { width: 800 },
+    full: { width: 1200 }
+  },
+  format: 'webp',
+  base: 'auto',
+  quality: 82
+};
+
+const isHiddenFile = (candidate: string) => path.basename(candidate).startsWith('.');
+
+export interface ThumbnailSummary {
+  config: ThumbnailConfig;
+  stats: {
+    totalFiles: number;
+    totalSize: number;
+    presets: number;
+  };
+}
+
+export class ThumbnailService {
+  private config: ThumbnailConfig = DEFAULT_CONFIG;
+  private watcher?: chokidar.FSWatcher;
+  private processing = new Map<string, Promise<void>>();
+
+  async ensureReady() {
+    await fs.mkdir(path.dirname(THUMBNAIL_CONFIG_FILE), { recursive: true });
+    await fs.mkdir(THUMBNAILS_ROOT, { recursive: true });
+
+    this.config = await this.readConfig();
+
+    if (!this.watcher) {
+      this.startWatching();
+    }
+  }
+
+  private async readConfig(): Promise<ThumbnailConfig> {
+    try {
+      const raw = await fs.readFile(THUMBNAIL_CONFIG_FILE, 'utf-8');
+      const parsed = JSON.parse(raw);
+      return thumbnailConfigSchema.parse(parsed);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        await this.writeConfig(DEFAULT_CONFIG);
+        return DEFAULT_CONFIG;
+      }
+      throw error;
+    }
+  }
+
+  private async writeConfig(config: ThumbnailConfig) {
+    await fs.writeFile(THUMBNAIL_CONFIG_FILE, JSON.stringify(config, null, 2), 'utf-8');
+  }
+
+  private startWatching() {
+    this.watcher = chokidar.watch(MEDIA_ROOT, {
+      ignoreInitial: false,
+      depth: 8,
+      awaitWriteFinish: { stabilityThreshold: 750, pollInterval: 120 }
+    });
+
+    const queue = async (relative: string, task: () => Promise<void>) => {
+      const normalized = toPosix(relative);
+      if (this.processing.has(normalized)) return;
+      const promise = task()
+        .catch((error) => {
+          console.error('thumbnail task failed', normalized, error);
+        })
+        .finally(() => {
+          this.processing.delete(normalized);
+        });
+      this.processing.set(normalized, promise);
+    };
+
+    this.watcher.on('add', (file) => {
+      if (!this.isImageFile(file)) return;
+      const relative = relativeMediaPath(file);
+      queue(relative, () => this.generateFor(relative));
+    });
+
+    this.watcher.on('change', (file) => {
+      if (!this.isImageFile(file)) return;
+      const relative = relativeMediaPath(file);
+      queue(relative, () => this.generateFor(relative));
+    });
+
+    this.watcher.on('unlink', (file) => {
+      if (!this.isImageFile(file)) return;
+      const relative = relativeMediaPath(file);
+      queue(relative, () => this.cleanupFor(relative));
+    });
+  }
+
+  private isImageFile(absolutePath: string) {
+    const ext = path.extname(absolutePath).toLowerCase();
+    return IMAGE_EXTENSIONS.has(ext);
+  }
+
+  async getSummary(): Promise<ThumbnailSummary> {
+    const stats = await this.computeStats();
+    return {
+      config: this.config,
+      stats
+    };
+  }
+
+  async updateConfig(next: ThumbnailConfig) {
+    const parsed = thumbnailConfigSchema.parse(next);
+    this.config = parsed;
+    await this.writeConfig(parsed);
+    await this.rebuildAll();
+  }
+
+  async rebuildAll() {
+    await fs.rm(THUMBNAILS_ROOT, { recursive: true, force: true });
+    await fs.mkdir(THUMBNAILS_ROOT, { recursive: true });
+
+    const files = await this.collectImageFiles('');
+    for (const file of files) {
+      await this.generateFor(file);
+    }
+  }
+
+  private async collectImageFiles(relative: string): Promise<string[]> {
+    const current = relative ? path.join(MEDIA_ROOT, relative) : MEDIA_ROOT;
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    const result: string[] = [];
+
+    for (const entry of entries) {
+      if (isHiddenFile(entry.name)) continue;
+      const entryPath = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        result.push(...(await this.collectImageFiles(entryPath)));
+      } else if (this.isImageFile(path.join(current, entry.name))) {
+        result.push(toPosix(entryPath));
+      }
+    }
+
+    return result;
+  }
+
+  private async computeStats() {
+    const stack = [THUMBNAILS_ROOT];
+    let totalFiles = 0;
+    let totalSize = 0;
+
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) continue;
+      try {
+        const entries = await fs.readdir(current, { withFileTypes: true });
+        for (const entry of entries) {
+          const absolute = path.join(current, entry.name);
+          if (entry.isDirectory()) {
+            stack.push(absolute);
+          } else {
+            totalFiles += 1;
+            const { size } = await fs.stat(absolute);
+            totalSize += size;
+          }
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+
+    return {
+      totalFiles,
+      totalSize,
+      presets: Object.keys(this.config.formats).length
+    };
+  }
+
+  private buildResizeOptions(preset: ThumbnailPreset, orientation: 'horizontal' | 'vertical' | 'square'): ResizeOptions {
+    const options: ResizeOptions = { fit: 'inside', withoutEnlargement: true };
+
+    if (preset.width && preset.height) {
+      options.width = preset.width;
+      options.height = preset.height;
+      options.fit = 'cover';
+      return options;
+    }
+
+    if (this.config.base === 'width') {
+      if (preset.width) options.width = preset.width;
+      if (preset.height) options.height = preset.height;
+      return options;
+    }
+
+    if (this.config.base === 'height') {
+      if (preset.height) options.height = preset.height;
+      if (preset.width) options.width = preset.width;
+      return options;
+    }
+
+    // auto behaviour: use width for horizontal, height for vertical, fallback for square
+    if (orientation === 'horizontal') {
+      if (preset.width) options.width = preset.width;
+      if (preset.height) options.height = preset.height;
+    } else if (orientation === 'vertical') {
+      if (preset.height) options.height = preset.height;
+      if (preset.width) options.width = preset.width;
+    } else {
+      if (preset.width) options.width = preset.width;
+      if (preset.height) options.height = preset.height;
+    }
+
+    return options;
+  }
+
+  private determineOrientation(width?: number, height?: number): 'horizontal' | 'vertical' | 'square' {
+    if (!width || !height) return 'horizontal';
+    if (Math.abs(width - height) < 8) return 'square';
+    return width >= height ? 'horizontal' : 'vertical';
+  }
+
+  private async removeExistingThumbnails(relativePath: string) {
+    const parsed = path.parse(relativePath);
+    const folder = path.join(THUMBNAILS_ROOT, parsed.dir);
+    try {
+      const entries = await fs.readdir(folder);
+      await Promise.all(
+        entries
+          .filter((name) => name.startsWith(`${parsed.name}_`))
+          .map((name) => fs.rm(path.join(folder, name), { force: true }))
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  private async generateFor(relativePath: string) {
+    try {
+      const absolute = path.join(MEDIA_ROOT, relativePath);
+      const meta = await sharp(absolute).metadata();
+      const width = meta.width;
+      const height = meta.height;
+      const orientation = this.determineOrientation(width, height);
+      const presets = Object.entries(this.config.formats);
+      const formats = resolveOutputFormats(this.config);
+
+      await this.removeExistingThumbnails(relativePath);
+
+      const thumbnailEntries: Record<string, MediaThumbnail> = {};
+
+      for (const [presetName, presetConfig] of presets) {
+        const resizeOptions = this.buildResizeOptions(presetConfig, orientation);
+        if (!resizeOptions.width && !resizeOptions.height) {
+          continue;
+        }
+        const sources: MediaThumbnail['sources'] = [];
+        let defaultPath = '';
+        let outputWidth: number | undefined;
+        let outputHeight: number | undefined;
+
+        for (const format of formats) {
+          const info = await this.writeThumbnail(relativePath, presetName, format, resizeOptions);
+          const relativeThumbPath = this.buildThumbnailPath(relativePath, presetName, format);
+          sources.push({ format, path: relativeThumbPath, size: info.size });
+          defaultPath = defaultPath || relativeThumbPath;
+          outputWidth = info.width ?? outputWidth;
+          outputHeight = info.height ?? outputHeight;
+        }
+
+        if (sources.length > 0) {
+          thumbnailEntries[presetName] = {
+            defaultPath,
+            sources,
+            width: outputWidth,
+            height: outputHeight
+          };
+        }
+      }
+
+      const existing: MediaMetadata =
+        (await metadataStore.getMediaMeta(relativePath)) ?? ({ visibility: 'public' } as MediaMetadata);
+      const next: MediaMetadata = {
+        ...existing,
+        visibility: existing.visibility ?? 'public',
+        width: width ?? existing.width,
+        height: height ?? existing.height,
+        orientation,
+        thumbnails: Object.keys(thumbnailEntries).length > 0 ? thumbnailEntries : undefined
+      };
+
+      await metadataStore.upsertMediaMeta(relativePath, next);
+    } catch (error) {
+      console.error('Failed to generate thumbnails for', relativePath, error);
+    }
+  }
+
+  private buildThumbnailPath(relativePath: string, preset: string, format: ThumbnailFormat) {
+    const parsed = path.parse(relativePath);
+    const fileName = `${parsed.name}_${preset}.${format}`;
+    return path.posix.join('/thumbnails', parsed.dir || '', fileName);
+  }
+
+  private async writeThumbnail(
+    relativePath: string,
+    preset: string,
+    format: ThumbnailFormat,
+    resizeOptions: ResizeOptions
+  ) {
+    const parsed = path.parse(relativePath);
+    const destinationFolder = path.join(THUMBNAILS_ROOT, parsed.dir);
+    await fs.mkdir(destinationFolder, { recursive: true });
+    const fileName = `${parsed.name}_${preset}.${format}`;
+    const destination = path.join(destinationFolder, fileName);
+
+    const pipeline = sharp(path.join(MEDIA_ROOT, relativePath)).rotate().resize(resizeOptions);
+
+    if (format === 'webp') {
+      pipeline.webp({ quality: this.config.quality, effort: 4 });
+    } else {
+      pipeline.avif({ quality: this.config.quality });
+    }
+
+    return pipeline.toFile(destination);
+  }
+
+  private async cleanupFor(relativePath: string) {
+    await this.removeExistingThumbnails(relativePath);
+    await metadataStore.deleteMediaMeta(relativePath);
+  }
+}
+
+export const thumbnailService = new ThumbnailService();

--- a/backend/src/types/metadata.ts
+++ b/backend/src/types/metadata.ts
@@ -32,6 +32,19 @@ export const mediaVariantSchema = z.object({
   size: z.number().optional()
 });
 
+export const mediaThumbnailSourceSchema = z.object({
+  format: z.string(),
+  path: z.string(),
+  size: z.number().optional()
+});
+
+export const mediaThumbnailSchema = z.object({
+  defaultPath: z.string(),
+  sources: z.array(mediaThumbnailSourceSchema).default([]),
+  width: z.number().optional(),
+  height: z.number().optional()
+});
+
 export const mediaMetadataSchema = z.object({
   title: z.string().optional(),
   description: z.string().optional(),
@@ -41,11 +54,17 @@ export const mediaMetadataSchema = z.object({
   visibility: z.enum(['public', 'private']).default('public'),
   focalPoint: z.object({ x: z.number(), y: z.number() }).optional(),
   colorPalette: z.array(z.string()).optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  orientation: z.enum(['horizontal', 'vertical', 'square']).optional(),
+  thumbnails: z.record(mediaThumbnailSchema).optional(),
   updatedAt: z.string().optional(),
   createdAt: z.string().optional()
 });
 
 export type MediaMetadata = z.infer<typeof mediaMetadataSchema>;
+export type MediaThumbnail = z.infer<typeof mediaThumbnailSchema>;
+export type MediaThumbnailSource = z.infer<typeof mediaThumbnailSourceSchema>;
 
 export type FolderMetadataRecord = Record<string, FolderMetadata>;
 export type MediaMetadataRecord = Record<string, MediaMetadata>;

--- a/backend/src/types/thumbnails.ts
+++ b/backend/src/types/thumbnails.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const thumbnailPresetSchema = z
+  .object({
+    width: z.number().int().positive().optional(),
+    height: z.number().int().positive().optional()
+  })
+  .refine((value) => value.width !== undefined || value.height !== undefined, {
+    message: 'Un format doit définir une largeur ou une hauteur.'
+  });
+
+export const thumbnailConfigSchema = z
+  .object({
+    formats: z.record(thumbnailPresetSchema).default({}),
+    format: z.enum(['webp', 'avif', 'both']).default('webp'),
+    base: z.enum(['auto', 'width', 'height']).default('auto'),
+    quality: z.number().int().min(1).max(100).default(82)
+  })
+  .passthrough();
+
+export type ThumbnailPreset = z.infer<typeof thumbnailPresetSchema>;
+export type ThumbnailConfig = z.infer<typeof thumbnailConfigSchema>;
+
+export type ThumbnailFormat = 'webp' | 'avif';
+
+export const resolveOutputFormats = (config: ThumbnailConfig): ThumbnailFormat[] =>
+  config.format === 'both' ? ['webp', 'avif'] : [config.format];

--- a/config/thumbnails.json
+++ b/config/thumbnails.json
@@ -1,0 +1,10 @@
+{
+  "formats": {
+    "thumb": { "width": 320 },
+    "medium": { "width": 800 },
+    "full": { "width": 1200 }
+  },
+  "format": "webp",
+  "base": "auto",
+  "quality": 82
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 import useSWR, { mutate } from 'swr';
-import { FolderNode, Orphans, Settings } from './types.js';
+import { FolderNode, Orphans, Settings, ThumbnailSummary } from './types.js';
 
 const fetcher = async (url: string) => {
   const response = await fetch(url);
@@ -12,6 +12,7 @@ const fetcher = async (url: string) => {
 export const useTree = () => useSWR<FolderNode>('/api/tree', fetcher, { suspense: false });
 export const useSettings = () => useSWR<Settings>('/api/settings', fetcher);
 export const useOrphans = () => useSWR<Orphans>('/api/orphans', fetcher, { refreshInterval: 1000 * 60 });
+export const useThumbnails = () => useSWR<ThumbnailSummary>('/api/thumbnails', fetcher);
 
 const postJson = async (url: string, body: unknown, method: string = 'POST') => {
   const response = await fetch(url, {
@@ -69,6 +70,16 @@ export const api = {
   async updateSettings(settings: Settings) {
     await postJson('/api/settings', settings, 'PUT');
     await mutate('/api/settings');
+  },
+  async updateThumbnails(config: ThumbnailSummary['config']) {
+    await postJson('/api/thumbnails', config, 'PUT');
+    await mutate('/api/thumbnails');
+    await mutate('/api/tree');
+  },
+  async rebuildThumbnails() {
+    await postJson('/api/thumbnails/rebuild', {}, 'POST');
+    await mutate('/api/thumbnails');
+    await mutate('/api/tree');
   },
   async requestPreview(secret: string, folder?: string, media?: string) {
     return postJson('/api/previews', { secret, folder, media });

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -31,6 +31,19 @@ export type MediaVariant = {
   size?: number;
 };
 
+export type MediaThumbnailSource = {
+  format: string;
+  path: string;
+  size?: number;
+};
+
+export type MediaThumbnail = {
+  defaultPath: string;
+  sources: MediaThumbnailSource[];
+  width?: number;
+  height?: number;
+};
+
 export type MediaNode = {
   type: 'media';
   name: string;
@@ -46,6 +59,10 @@ export type MediaNode = {
   variants?: MediaVariant[];
   focalPoint?: { x: number; y: number };
   colorPalette?: string[];
+  width?: number;
+  height?: number;
+  orientation?: 'horizontal' | 'vertical' | 'square';
+  thumbnails?: Record<string, MediaThumbnail>;
 };
 
 export type Settings = {
@@ -80,6 +97,22 @@ export type Settings = {
   previews: {
     enabled: boolean;
     tokenExpirationMinutes: number;
+  };
+};
+
+export type ThumbnailConfig = {
+  formats: Record<string, { width?: number; height?: number }>;
+  format: 'webp' | 'avif' | 'both';
+  base: 'auto' | 'width' | 'height';
+  quality: number;
+};
+
+export type ThumbnailSummary = {
+  config: ThumbnailConfig;
+  stats: {
+    totalFiles: number;
+    totalSize: number;
+    presets: number;
   };
 };
 

--- a/frontend/src/components/MediaEditor.tsx
+++ b/frontend/src/components/MediaEditor.tsx
@@ -42,6 +42,23 @@ export const MediaEditor: React.FC<Props> = ({ media, settings, onSaveMetadata, 
   const [previewSecret, setPreviewSecret] = useState('');
   const [previewToken, setPreviewToken] = useState<string | null>(null);
 
+  const orientationLabel =
+    media.orientation === 'horizontal'
+      ? 'Paysage'
+      : media.orientation === 'vertical'
+      ? 'Portrait'
+      : media.orientation === 'square'
+      ? 'Carré'
+      : undefined;
+
+  const formatBytes = (bytes: number) => {
+    if (!bytes) return '';
+    const units = ['o', 'Ko', 'Mo', 'Go'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, exponent);
+    return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[exponent]}`;
+  };
+
   useEffect(() => {
     setTitle(media.title || '');
     setTags(media.tags?.join(', ') || '');
@@ -126,6 +143,10 @@ export const MediaEditor: React.FC<Props> = ({ media, settings, onSaveMetadata, 
         </Typography>
         <Stack direction="row" spacing={1} mt={1} flexWrap="wrap">
           <Chip label={media.mimeType || 'type inconnu'} size="small" />
+          {media.width && media.height && (
+            <Chip label={`${media.width}×${media.height}`} size="small" variant="outlined" />
+          )}
+          {orientationLabel && <Chip label={orientationLabel} size="small" variant="outlined" />}
           {media.variants?.map((variant) => (
             <Chip key={variant.path} label={`${variant.format}`} size="small" variant="outlined" />
           ))}
@@ -156,6 +177,50 @@ export const MediaEditor: React.FC<Props> = ({ media, settings, onSaveMetadata, 
       />
 
       <Divider sx={{ borderStyle: 'dashed' }} />
+
+      {media.thumbnails && Object.keys(media.thumbnails).length > 0 && (
+        <Box>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>
+            Miniatures générées
+          </Typography>
+          <Stack spacing={1.5}>
+            {Object.entries(media.thumbnails).map(([name, thumb]) => {
+              const totalSize = thumb.sources.reduce((sum, source) => sum + (source.size ?? 0), 0);
+              return (
+                <Stack
+                  key={name}
+                  direction={{ xs: 'column', md: 'row' }}
+                  spacing={1}
+                  alignItems={{ xs: 'flex-start', md: 'center' }}
+                >
+                  <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                    <Chip label={name} color="primary" size="small" />
+                    {thumb.width && thumb.height && (
+                      <Chip label={`${thumb.width}×${thumb.height}`} size="small" variant="outlined" />
+                    )}
+                    {thumb.sources.map((source) => (
+                      <Chip
+                        key={`${name}-${source.format}`}
+                        label={source.format}
+                        size="small"
+                        variant="outlined"
+                      />
+                    ))}
+                    {totalSize > 0 && <Chip label={formatBytes(totalSize)} size="small" />}
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary">
+                    {thumb.defaultPath}
+                  </Typography>
+                </Stack>
+              );
+            })}
+          </Stack>
+        </Box>
+      )}
+
+      {media.thumbnails && Object.keys(media.thumbnails).length > 0 && (
+        <Divider sx={{ borderStyle: 'dashed' }} />
+      )}
 
       <Box>
         <Typography variant="subtitle1" sx={{ mb: 1 }}>

--- a/frontend/src/components/MediaGrid.tsx
+++ b/frontend/src/components/MediaGrid.tsx
@@ -25,42 +25,65 @@ export const MediaGrid: React.FC<Props> = ({ medias, selectedPath, onSelect }) =
 
   return (
     <Stack direction="row" flexWrap="wrap" gap={2}>
-      {medias.map((media) => (
-        <MotionCard
-          key={media.path}
-          onClick={() => onSelect(media.path)}
-          whileHover={{ y: -4, boxShadow: '0 12px 24px rgba(111, 137, 166, 0.16)' }}
-          transition={{ type: 'spring', stiffness: 320, damping: 22 }}
-          sx={{
-            width: 200,
-            borderRadius: 4,
-            border: media.path === selectedPath ? '2px solid #6f89a6' : '1px solid rgba(111,137,166,0.2)',
-            position: 'relative'
-          }}
-        >
-          <CardActionArea sx={{ height: 120, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 2 }}>
-            <ImageIcon fontSize="large" color="disabled" />
-          </CardActionArea>
-          <CardContent sx={{ minHeight: 100 }}>
-            <Stack spacing={0.5}>
-              <Typography variant="subtitle2" noWrap>
-                {media.title || media.name}
-              </Typography>
-              <Typography variant="caption" color="text.secondary" noWrap>
-                {media.path}
-              </Typography>
-              <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                {media.tags?.slice(0, 3).map((tag) => (
-                  <Chip key={tag} label={tag} size="small" variant="outlined" />
-                ))}
-                {media.visibility === 'private' && (
-                  <Chip icon={<VisibilityOffIcon />} label="Privé" size="small" color="warning" variant="outlined" />
-                )}
+      {medias.map((media) => {
+        const thumbnails = media.thumbnails && Object.keys(media.thumbnails).length > 0 ? media.thumbnails : undefined;
+        const primary = thumbnails ? thumbnails.thumb || Object.values(thumbnails)[0] : undefined;
+        const previewPath = primary?.defaultPath;
+
+        return (
+          <MotionCard
+            key={media.path}
+            onClick={() => onSelect(media.path)}
+            whileHover={{ y: -4, boxShadow: '0 12px 24px rgba(111, 137, 166, 0.16)' }}
+            transition={{ type: 'spring', stiffness: 320, damping: 22 }}
+            sx={{
+              width: 200,
+              borderRadius: 4,
+              border: media.path === selectedPath ? '2px solid #6f89a6' : '1px solid rgba(111,137,166,0.2)',
+              position: 'relative'
+            }}
+          >
+            <CardActionArea
+              sx={{ height: 140, display: 'flex', alignItems: 'center', justifyContent: 'center', p: 1.5 }}
+            >
+              {previewPath ? (
+                <img
+                  src={`/api/media${previewPath}`}
+                  alt={media.title || media.name}
+                  loading="lazy"
+                  style={{
+                    maxWidth: '100%',
+                    maxHeight: '100%',
+                    objectFit: 'cover',
+                    borderRadius: 8,
+                    boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.6)'
+                  }}
+                />
+              ) : (
+                <ImageIcon fontSize="large" color="disabled" />
+              )}
+            </CardActionArea>
+            <CardContent sx={{ minHeight: 100 }}>
+              <Stack spacing={0.5}>
+                <Typography variant="subtitle2" noWrap>
+                  {media.title || media.name}
+                </Typography>
+                <Typography variant="caption" color="text.secondary" noWrap>
+                  {media.path}
+                </Typography>
+                <Stack direction="row" spacing={0.5} flexWrap="wrap">
+                  {media.tags?.slice(0, 3).map((tag) => (
+                    <Chip key={tag} label={tag} size="small" variant="outlined" />
+                  ))}
+                  {media.visibility === 'private' && (
+                    <Chip icon={<VisibilityOffIcon />} label="Privé" size="small" color="warning" variant="outlined" />
+                  )}
+                </Stack>
               </Stack>
-            </Stack>
-          </CardContent>
-        </MotionCard>
-      ))}
+            </CardContent>
+          </MotionCard>
+        );
+      })}
     </Stack>
   );
 };

--- a/frontend/src/components/ThumbnailSettingsPanel.tsx
+++ b/frontend/src/components/ThumbnailSettingsPanel.tsx
@@ -1,0 +1,286 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Divider,
+  Grid,
+  MenuItem,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/AddRounded';
+import DeleteIcon from '@mui/icons-material/DeleteRounded';
+import RefreshIcon from '@mui/icons-material/AutoFixHighRounded';
+import InfoIcon from '@mui/icons-material/InfoOutlined';
+import { ThumbnailSummary } from '../api/types.js';
+
+interface Props {
+  summary: ThumbnailSummary;
+  onSave: (config: ThumbnailSummary['config']) => Promise<void> | void;
+  onRebuild: () => Promise<void> | void;
+}
+
+const formatBytes = (bytes: number) => {
+  if (bytes === 0) return '0 o';
+  const units = ['o', 'Ko', 'Mo', 'Go'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, exponent);
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[exponent]}`;
+};
+
+export const ThumbnailSettingsPanel: React.FC<Props> = ({ summary, onSave, onRebuild }) => {
+  const [draft, setDraft] = useState(summary.config);
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageType, setMessageType] = useState<'success' | 'error'>('success');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isRebuilding, setIsRebuilding] = useState(false);
+
+  useEffect(() => {
+    setDraft(summary.config);
+  }, [summary.config]);
+
+  const addFormat = () => {
+    const id = `format-${Date.now()}`;
+    setDraft((prev) => ({
+      ...prev,
+      formats: {
+        ...prev.formats,
+        [id]: { width: 400 }
+      }
+    }));
+  };
+
+  const updateFormatValue = (key: string, value: { width?: number; height?: number }) => {
+    setDraft((prev) => ({
+      ...prev,
+      formats: {
+        ...prev.formats,
+        [key]: value
+      }
+    }));
+  };
+
+  const renameFormat = (currentKey: string, nextKey: string) => {
+    if (!nextKey || currentKey === nextKey) return;
+    setDraft((prev) => {
+      if (prev.formats[nextKey]) {
+        return prev;
+      }
+      const nextFormats = { ...prev.formats };
+      const value = nextFormats[currentKey];
+      delete nextFormats[currentKey];
+      nextFormats[nextKey] = value;
+      return { ...prev, formats: nextFormats };
+    });
+  };
+
+  const removeFormat = (key: string) => {
+    setDraft((prev) => {
+      const nextFormats = { ...prev.formats };
+      delete nextFormats[key];
+      return { ...prev, formats: nextFormats };
+    });
+  };
+
+  const save = async () => {
+    setIsSaving(true);
+    try {
+      await onSave(draft);
+      setMessage('Configuration des miniatures sauvegardée 🌈');
+      setMessageType('success');
+    } catch (error) {
+      setMessage((error as Error).message);
+      setMessageType('error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const rebuild = async () => {
+    setIsRebuilding(true);
+    setMessage(null);
+    try {
+      await onRebuild();
+      setMessage('Regénération programmée ✨');
+      setMessageType('success');
+    } catch (error) {
+      setMessage((error as Error).message);
+      setMessageType('error');
+    } finally {
+      setIsRebuilding(false);
+    }
+  };
+
+  const presets = useMemo(() => Object.entries(draft.formats), [draft.formats]);
+
+  return (
+    <Stack spacing={3}>
+      {message && <Alert severity={messageType}>{message}</Alert>}
+      <Card variant="outlined">
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center" justifyContent="space-between">
+            <Box>
+              <Typography variant="h6">Formats configurés</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Ajoutez des tailles adaptées à vos galeries responsive.
+              </Typography>
+            </Box>
+            <Button startIcon={<AddIcon />} variant="outlined" onClick={addFormat}>
+              Ajouter un format
+            </Button>
+          </Stack>
+          <Divider sx={{ my: 3 }} />
+          <Stack spacing={2}>
+            {presets.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                Aucun format défini. Ajoutez au moins une miniature pour profiter des optimisations.
+              </Typography>
+            )}
+            {presets.map(([key, value]) => (
+              <Card key={key} variant="outlined" sx={{ borderStyle: 'dashed' }}>
+                <CardContent>
+                  <Grid container spacing={2} alignItems="center">
+                    <Grid item xs={12} md={3}>
+                      <TextField
+                        label="Nom du format"
+                        value={key}
+                        onChange={(event) => renameFormat(key, event.target.value.trim())}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={12} sm={6} md={3}>
+                      <TextField
+                        label="Largeur cible"
+                        type="number"
+                        value={value.width ?? ''}
+                        onChange={(event) =>
+                          updateFormatValue(key, {
+                            ...value,
+                            width: event.target.value ? Number(event.target.value) : undefined
+                          })
+                        }
+                        InputProps={{ inputProps: { min: 1 } }}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={12} sm={6} md={3}>
+                      <TextField
+                        label="Hauteur cible"
+                        type="number"
+                        value={value.height ?? ''}
+                        onChange={(event) =>
+                          updateFormatValue(key, {
+                            ...value,
+                            height: event.target.value ? Number(event.target.value) : undefined
+                          })
+                        }
+                        InputProps={{ inputProps: { min: 1 } }}
+                        fullWidth
+                      />
+                    </Grid>
+                    <Grid item xs={12} md={3}>
+                      <Stack direction="row" justifyContent="flex-end">
+                        <Button color="error" startIcon={<DeleteIcon />} onClick={() => removeFormat(key)}>
+                          Supprimer
+                        </Button>
+                      </Stack>
+                    </Grid>
+                  </Grid>
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Paramètres globaux
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={4}>
+              <TextField
+                select
+                label="Format de sortie"
+                value={draft.format}
+                onChange={(event) => setDraft({ ...draft, format: event.target.value as typeof draft.format })}
+                fullWidth
+              >
+                <MenuItem value="webp">webp (compatible et léger)</MenuItem>
+                <MenuItem value="avif">avif (très optimisé)</MenuItem>
+                <MenuItem value="both">webp + avif (choix automatique)</MenuItem>
+              </TextField>
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <TextField
+                select
+                label="Dimension de base"
+                value={draft.base}
+                onChange={(event) => setDraft({ ...draft, base: event.target.value as typeof draft.base })}
+                fullWidth
+              >
+                <MenuItem value="auto">Automatique (selon orientation)</MenuItem>
+                <MenuItem value="width">Basé sur la largeur</MenuItem>
+                <MenuItem value="height">Basé sur la hauteur</MenuItem>
+              </TextField>
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <TextField
+                label="Qualité"
+                type="number"
+                value={draft.quality}
+                onChange={(event) =>
+                  setDraft({ ...draft, quality: event.target.value ? Number(event.target.value) : 82 })
+                }
+                helperText="Entre 1 et 100"
+                InputProps={{ inputProps: { min: 1, max: 100 } }}
+                fullWidth
+              />
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
+            <Box sx={{ flex: 1 }}>
+              <Typography variant="subtitle1">Utilisation disque actuelle</Typography>
+              <Typography variant="body2" color="text.secondary">
+                {summary.stats.presets} formats · {summary.stats.totalFiles} fichiers ·{' '}
+                {formatBytes(summary.stats.totalSize)}
+              </Typography>
+            </Box>
+            <Tooltip title="Recalculer toutes les miniatures">
+              <span>
+                <Button
+                  variant="outlined"
+                  startIcon={<RefreshIcon />}
+                  onClick={rebuild}
+                  disabled={isRebuilding || presets.length === 0}
+                >
+                  Recalculer toutes les miniatures
+                </Button>
+              </span>
+            </Tooltip>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
+        <Button variant="contained" onClick={save} disabled={isSaving}>
+          Sauvegarder la configuration
+        </Button>
+        <Tooltip title="Les miniatures sont générées automatiquement au prochain ajout." placement="right">
+          <InfoIcon color="action" />
+        </Tooltip>
+      </Stack>
+    </Stack>
+  );
+};

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,10 +5,13 @@ import {
   Button,
   Card,
   CardContent,
+  CircularProgress,
   Divider,
   Grid,
   MenuItem,
   Stack,
+  Tab,
+  Tabs,
   TextField,
   Typography
 } from '@mui/material';
@@ -16,7 +19,8 @@ import PaletteIcon from '@mui/icons-material/PaletteRounded';
 import AddIcon from '@mui/icons-material/AddRounded';
 import DeleteIcon from '@mui/icons-material/DeleteRounded';
 import { Settings } from '../api/types.js';
-import { api } from '../api/client.js';
+import { api, useThumbnails } from '../api/client.js';
+import { ThumbnailSettingsPanel } from '../components/ThumbnailSettingsPanel.js';
 
 interface Props {
   settings: Settings;
@@ -26,6 +30,8 @@ export const SettingsPage: React.FC<Props> = ({ settings }) => {
   const [draft, setDraft] = useState(settings);
   const [message, setMessage] = useState<string | null>(null);
   const [messageType, setMessageType] = useState<'success' | 'error'>('success');
+  const [tab, setTab] = useState<'general' | 'thumbnails'>('general');
+  const { data: thumbnailSummary, error: thumbnailError } = useThumbnails();
 
   const updateAttribute = (index: number, key: keyof Settings['attributeTypes'][number], value: any) => {
     const next = { ...draft };
@@ -63,112 +69,145 @@ export const SettingsPage: React.FC<Props> = ({ settings }) => {
 
   return (
     <Stack spacing={4} sx={{ p: 4 }}>
-      {message && <Alert severity={messageType}>{message}</Alert>}
       <Box>
         <Typography variant="h4" sx={{ fontWeight: 700 }}>
           Paramètres de l'atelier
         </Typography>
         <Typography variant="subtitle1" color="text.secondary">
-          Définissez le vocabulaire des métadonnées et les couleurs du front.
+          Définissez le vocabulaire des métadonnées, l'identité visuelle et les miniatures.
         </Typography>
       </Box>
 
-      <Card variant="outlined">
-        <CardContent>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <PaletteIcon color="primary" />
-            <Typography variant="h6">Palette et ambiance</Typography>
-          </Stack>
-          <Grid container spacing={2} sx={{ mt: 2 }}>
-            <Grid item xs={12} md={4}>
-              <TextField
-                label="Thème"
-                value={draft.ui.theme}
-                onChange={(event) => setDraft({ ...draft, ui: { ...draft.ui, theme: event.target.value } })}
-                fullWidth
-              />
-            </Grid>
-            <Grid item xs={12} md={4}>
-              <TextField
-                label="Couleur d'accent"
-                type="color"
-                value={draft.ui.accentColor}
-                onChange={(event) => setDraft({ ...draft, ui: { ...draft.ui, accentColor: event.target.value } })}
-                fullWidth
-              />
-            </Grid>
-            <Grid item xs={12} md={4}>
-              <TextField
-                label="Couleur papier"
-                type="color"
-                value={draft.ui.paperColor}
-                onChange={(event) => setDraft({ ...draft, ui: { ...draft.ui, paperColor: event.target.value } })}
-                fullWidth
-              />
-            </Grid>
-          </Grid>
-        </CardContent>
-      </Card>
+      <Tabs
+        value={tab}
+        onChange={(_event, value) => setTab(value)}
+        textColor="primary"
+        indicatorColor="primary"
+        sx={{ borderBottom: '1px solid rgba(111,137,166,0.2)' }}
+      >
+        <Tab label="Général" value="general" />
+        <Tab label="Miniatures" value="thumbnails" />
+      </Tabs>
 
-      <Card variant="outlined">
-        <CardContent>
-          <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
-            <Typography variant="h6">Types d'attributs</Typography>
-            <Button startIcon={<AddIcon />} onClick={addAttribute} variant="outlined">
-              Ajouter un type
-            </Button>
-          </Stack>
-          <Divider sx={{ my: 2 }} />
-          <Stack spacing={2}>
-            {draft.attributeTypes.map((attribute, index) => (
-              <Stack key={attribute.id} direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
-                <TextField
-                  label="Identifiant"
-                  value={attribute.id}
-                  onChange={(event) => updateAttribute(index, 'id', event.target.value)}
-                  size="small"
-                />
-                <TextField
-                  label="Label"
-                  value={attribute.label}
-                  onChange={(event) => updateAttribute(index, 'label', event.target.value)}
-                  size="small"
-                />
-                <TextField
-                  select
-                  label="Composant"
-                  value={attribute.input}
-                  onChange={(event) => updateAttribute(index, 'input', event.target.value)}
-                  size="small"
-                  sx={{ minWidth: 160 }}
-                >
-                  {['text', 'textarea', 'checkbox', 'date', 'number', 'link', 'image', 'select', 'color'].map((option) => (
-                    <MenuItem key={option} value={option}>
-                      {option}
-                    </MenuItem>
-                  ))}
-                </TextField>
-                <TextField
-                  label="Options (sélection)"
-                  value={attribute.options?.join(', ') || ''}
-                  onChange={(event) =>
-                    updateAttribute(index, 'options', event.target.value.split(',').map((value: string) => value.trim()))
-                  }
-                  size="small"
-                  sx={{ flex: 1 }}
-                />
-                <Button color="error" startIcon={<DeleteIcon />} onClick={() => removeAttribute(index)}>
-                  Retirer
+      {tab === 'general' && (
+        <Stack spacing={4}>
+          {message && <Alert severity={messageType}>{message}</Alert>}
+          <Card variant="outlined">
+            <CardContent>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <PaletteIcon color="primary" />
+                <Typography variant="h6">Palette et ambiance</Typography>
+              </Stack>
+              <Grid container spacing={2} sx={{ mt: 2 }}>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Thème"
+                    value={draft.ui.theme}
+                    onChange={(event) => setDraft({ ...draft, ui: { ...draft.ui, theme: event.target.value } })}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Couleur d'accent"
+                    type="color"
+                    value={draft.ui.accentColor}
+                    onChange={(event) => setDraft({ ...draft, ui: { ...draft.ui, accentColor: event.target.value } })}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Couleur papier"
+                    type="color"
+                    value={draft.ui.paperColor}
+                    onChange={(event) => setDraft({ ...draft, ui: { ...draft.ui, paperColor: event.target.value } })}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
+            </CardContent>
+          </Card>
+
+          <Card variant="outlined">
+            <CardContent>
+              <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                <Typography variant="h6">Types d'attributs</Typography>
+                <Button startIcon={<AddIcon />} onClick={addAttribute} variant="outlined">
+                  Ajouter un type
                 </Button>
               </Stack>
-            ))}
-          </Stack>
-        </CardContent>
-      </Card>
+              <Divider sx={{ my: 2 }} />
+              <Stack spacing={2}>
+                {draft.attributeTypes.map((attribute, index) => (
+                  <Stack key={attribute.id} direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="center">
+                    <TextField
+                      label="Identifiant"
+                      value={attribute.id}
+                      onChange={(event) => updateAttribute(index, 'id', event.target.value)}
+                      size="small"
+                    />
+                    <TextField
+                      label="Label"
+                      value={attribute.label}
+                      onChange={(event) => updateAttribute(index, 'label', event.target.value)}
+                      size="small"
+                    />
+                    <TextField
+                      select
+                      label="Composant"
+                      value={attribute.input}
+                      onChange={(event) => updateAttribute(index, 'input', event.target.value)}
+                      size="small"
+                      sx={{ minWidth: 160 }}
+                    >
+                      {['text', 'textarea', 'checkbox', 'date', 'number', 'link', 'image', 'select', 'color'].map((option) => (
+                        <MenuItem key={option} value={option}>
+                          {option}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                    <TextField
+                      label="Options (sélection)"
+                      value={attribute.options?.join(', ') || ''}
+                      onChange={(event) =>
+                        updateAttribute(index, 'options', event.target.value.split(',').map((value: string) => value.trim()))
+                      }
+                      size="small"
+                      sx={{ flex: 1 }}
+                    />
+                    <Button color="error" startIcon={<DeleteIcon />} onClick={() => removeAttribute(index)}>
+                      Retirer
+                    </Button>
+                  </Stack>
+                ))}
+              </Stack>
+            </CardContent>
+          </Card>
 
-      <Button variant="contained" size="large" onClick={save} sx={{ alignSelf: 'flex-start' }}>
-        Sauvegarder les réglages
-      </Button>
+          <Button variant="contained" size="large" onClick={save} sx={{ alignSelf: 'flex-start' }}>
+            Sauvegarder les réglages
+          </Button>
+        </Stack>
+      )}
+
+      {tab === 'thumbnails' && (
+        <Box>
+          {thumbnailError && <Alert severity="error">{thumbnailError.message}</Alert>}
+          {!thumbnailSummary && !thumbnailError && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+              <CircularProgress />
+            </Box>
+          )}
+          {thumbnailSummary && (
+            <ThumbnailSettingsPanel
+              summary={thumbnailSummary}
+              onSave={(config) => api.updateThumbnails(config)}
+              onRebuild={() => api.rebuildThumbnails()}
+            />
+          )}
+        </Box>
+      )}
     </Stack>
   );
 };

--- a/site/components/GalleryStack.module.css
+++ b/site/components/GalleryStack.module.css
@@ -21,7 +21,13 @@
   background: linear-gradient(135deg, rgba(11, 74, 111, 0.12), rgba(192, 70, 60, 0.05));
 }
 
-.frame img {
+.frame picture {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.image {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/site/components/GalleryStack.tsx
+++ b/site/components/GalleryStack.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import clsx from "clsx";
+import Image from "next/image";
 
 import paperStyles from "./Paper.module.css";
 import styles from "./GalleryStack.module.css";
@@ -12,6 +13,12 @@ type GalleryItem = {
   mediaPath?: string;
   href?: string;
   hints?: string[];
+  image?: {
+    defaultPath: string;
+    width?: number;
+    height?: number;
+    sources: Array<{ format: string; path: string }>;
+  };
 };
 
 type GalleryStackProps = {
@@ -38,21 +45,49 @@ export function GalleryStack({ items }: GalleryStackProps) {
             layout
             whileHover={{ rotate: rotation * 0.6, y: -8 }}
             transition={{ type: "spring", stiffness: 180, damping: 18 }}
-          >
-            <a
-              className={clsx(paperStyles.base, paperStyles.gallery, paperStyles.stack, styles.card)}
-              href={linkHref}
-              {...linkProps}
             >
-              <div className={styles.frame}>
-                {item.mediaPath ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={`/api/media/${item.mediaPath}`} alt={item.label} loading="lazy" />
-                ) : (
-                  <div className={paperStyles.muted}>
-                    {item.hints?.slice(0, 3).join(" · ") ?? "Fragment à découvrir"}
-                  </div>
-                )}
+              <a
+                className={clsx(paperStyles.base, paperStyles.gallery, paperStyles.stack, styles.card)}
+                href={linkHref}
+                {...linkProps}
+              >
+                <div className={styles.frame}>
+                  {item.image ? (
+                    <picture>
+                      {item.image.sources.map((source) => (
+                        <source
+                          key={`${item.id}-${source.format}`}
+                          srcSet={`/api/media${source.path}`}
+                          type={`image/${source.format}`}
+                        />
+                      ))}
+                      <Image
+                        src={`/api/media${item.image.defaultPath}`}
+                        alt={item.label}
+                        width={item.image.width ?? 320}
+                        height={item.image.height ?? 240}
+                        className={styles.image}
+                        sizes="(max-width: 900px) 45vw, 320px"
+                        priority={index < 4}
+                        unoptimized
+                      />
+                    </picture>
+                  ) : item.mediaPath ? (
+                    <Image
+                      src={`/api/media/${item.mediaPath}`}
+                      alt={item.label}
+                      width={320}
+                      height={240}
+                      className={styles.image}
+                      sizes="(max-width: 900px) 45vw, 320px"
+                      priority={index < 4}
+                      unoptimized
+                    />
+                  ) : (
+                    <div className={paperStyles.muted}>
+                      {item.hints?.slice(0, 3).join(" · ") ?? "Fragment à découvrir"}
+                    </div>
+                  )}
               </div>
               <span className={styles.caption}>{item.label}</span>
             </a>

--- a/site/components/NavigationScene.tsx
+++ b/site/components/NavigationScene.tsx
@@ -21,6 +21,12 @@ type GalleryItem = {
   mediaPath?: string;
   href?: string;
   hints?: string[];
+  image?: {
+    defaultPath: string;
+    width?: number;
+    height?: number;
+    sources: Array<{ format: string; path: string }>;
+  };
 };
 
 type NavigationSceneProps = {

--- a/site/lib/mediaMetadata.ts
+++ b/site/lib/mediaMetadata.ts
@@ -1,0 +1,42 @@
+import { cache } from "react";
+import fs from "fs/promises";
+import path from "path";
+
+type ThumbnailSource = {
+  format: string;
+  path: string;
+  size?: number;
+};
+
+type ThumbnailEntry = {
+  defaultPath: string;
+  sources: ThumbnailSource[];
+  width?: number;
+  height?: number;
+};
+
+export type MediaMetadata = {
+  width?: number;
+  height?: number;
+  orientation?: "horizontal" | "vertical" | "square";
+  thumbnails?: Record<string, ThumbnailEntry>;
+};
+
+export type MediaMetadataRecord = Record<string, MediaMetadata>;
+
+const MEDIA_META_FILE = path.resolve(process.cwd(), "..", "medias", ".media-meta.json");
+
+async function readMetadata(): Promise<MediaMetadataRecord> {
+  try {
+    const raw = await fs.readFile(MEDIA_META_FILE, "utf-8");
+    const parsed = JSON.parse(raw) as MediaMetadataRecord;
+    return parsed;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+}
+
+export const getMediaMetadata = cache(readMetadata);


### PR DESCRIPTION
## Summary
- introduce a backend ThumbnailService that watches `/medias`, generates configured webp/avif presets with sharp, and persists paths in `.media-meta.json`
- expose thumbnail configuration endpoints, cache invalidations, and default config so admin can edit presets and trigger rebuilds
- update admin UI and public site to surface generated thumbnails, including a new settings tab, gallery previews, and Next.js media metadata loader

## Testing
- `cd backend && npm run build`
- `cd frontend && npm run build`
- `cd site && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cbc0da61748322acec12b05f87805d