### PR TITLE
feat: manage static pages from admin

### DIFF
--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -126,3 +126,25 @@ export type Orphans = {
     medias: string[];
   };
 };
+
+export type StaticPageColumn = {
+  id: string;
+  span: number;
+  content: string;
+};
+
+export type StaticPageSection = {
+  id: string;
+  columns: StaticPageColumn[];
+};
+
+export type StaticPage = {
+  id: string;
+  title: string;
+  slug: string;
+  visible: boolean;
+  order: number;
+  sections: StaticPageSection[];
+  createdAt: string;
+  updatedAt: string;
+};

--- a/admin/src/components/RichTextEditor.tsx
+++ b/admin/src/components/RichTextEditor.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Box, Divider, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import FormatBoldIcon from '@mui/icons-material/FormatBold';
+import FormatItalicIcon from '@mui/icons-material/FormatItalic';
+import FormatUnderlinedIcon from '@mui/icons-material/FormatUnderlined';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
+import LinkIcon from '@mui/icons-material/Link';
+import FormatQuoteIcon from '@mui/icons-material/FormatQuote';
+import TitleIcon from '@mui/icons-material/Title';
+
+interface RichTextEditorProps {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  label?: string;
+}
+
+type ToolbarCommand = {
+  icon: React.ReactNode;
+  command: string;
+  label: string;
+  value?: string;
+};
+
+const commands: ToolbarCommand[] = [
+  { icon: <FormatBoldIcon fontSize="small" />, command: 'bold', label: 'Gras' },
+  { icon: <FormatItalicIcon fontSize="small" />, command: 'italic', label: 'Italique' },
+  { icon: <FormatUnderlinedIcon fontSize="small" />, command: 'underline', label: 'Souligner' },
+  { icon: <FormatQuoteIcon fontSize="small" />, command: 'formatBlock', value: 'blockquote', label: 'Citation' },
+  { icon: <TitleIcon fontSize="small" />, command: 'formatBlock', value: 'h2', label: 'Titre' },
+  { icon: <FormatListBulletedIcon fontSize="small" />, command: 'insertUnorderedList', label: 'Liste à puces' },
+  { icon: <FormatListNumberedIcon fontSize="small" />, command: 'insertOrderedList', label: 'Liste numérotée' }
+];
+
+const createId = () => (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+export const RichTextEditor: React.FC<RichTextEditorProps> = ({ value, onChange, placeholder, label }) => {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const internalId = useMemo(createId, []);
+
+  useEffect(() => {
+    if (editorRef.current && editorRef.current.innerHTML !== value) {
+      editorRef.current.innerHTML = value || '';
+    }
+  }, [value]);
+
+  const handleCommand = (command: string, value?: string) => {
+    editorRef.current?.focus();
+    document.execCommand(command, false, value);
+    onChange(editorRef.current?.innerHTML ?? '');
+  };
+
+  const handleLink = () => {
+    const url = window.prompt('Adresse du lien ?');
+    if (url) {
+      handleCommand('createLink', url);
+    }
+  };
+
+  return (
+    <Stack spacing={1.5} sx={{ border: '1px solid rgba(111,137,166,0.3)', borderRadius: 2, overflow: 'hidden', background: '#fff' }}>
+      <Box sx={{ px: 1.5, py: 1, background: 'rgba(240,245,250,0.5)', display: 'flex', alignItems: 'center', gap: 1 }}>
+        {label && (
+          <Typography variant="caption" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.6 }}>
+            {label}
+          </Typography>
+        )}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {commands.map((item) => (
+            <Tooltip key={item.label} title={item.label} placement="top">
+              <IconButton size="small" onClick={() => handleCommand(item.command, item.value)}>
+                {item.icon}
+              </IconButton>
+            </Tooltip>
+          ))}
+          <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+          <Tooltip title="Insérer un lien" placement="top">
+            <IconButton size="small" onClick={handleLink}>
+              <LinkIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+      <Box
+        id={internalId}
+        ref={editorRef}
+        contentEditable
+        suppressContentEditableWarning
+        onInput={() => onChange(editorRef.current?.innerHTML ?? '')}
+        onBlur={() => onChange(editorRef.current?.innerHTML ?? '')}
+        sx={{
+          minHeight: 160,
+          px: 2,
+          py: 1.5,
+          outline: 'none',
+          '&:empty::before': {
+            content: `'${placeholder ?? 'Commencez à écrire...'}'`,
+            color: 'rgba(0,0,0,0.35)'
+          },
+          '& h2': {
+            margin: '0 0 0.4em',
+            fontSize: '1.4rem'
+          },
+          '& blockquote': {
+            borderLeft: '3px solid rgba(25, 118, 210, 0.35)',
+            margin: '0 0 1em',
+            padding: '0.2em 0 0.2em 1em',
+            color: 'rgba(0,0,0,0.7)'
+          },
+          '& ul, & ol': {
+            paddingLeft: '1.4em',
+            margin: '0 0 1em'
+          },
+          '& p': {
+            margin: '0 0 1em'
+          }
+        }}
+      />
+    </Stack>
+  );
+};

--- a/admin/src/components/Toolbar.tsx
+++ b/admin/src/components/Toolbar.tsx
@@ -8,7 +8,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { MetadataSyncIndicator } from './MetadataSyncIndicator.js';
 
 interface Props {
-  onRefresh: () => void;
+  onRefresh?: () => void;
   onNewFolder?: () => void;
   canGoBack?: boolean;
   title?: string;
@@ -18,6 +18,7 @@ export const Toolbar: React.FC<Props> = ({ onRefresh, onNewFolder, canGoBack, ti
   const location = useLocation();
   const navigate = useNavigate();
   const inSettings = location.pathname === '/settings';
+  const inPages = location.pathname.startsWith('/pages');
 
   return (
     <AppBar
@@ -49,14 +50,32 @@ export const Toolbar: React.FC<Props> = ({ onRefresh, onNewFolder, canGoBack, ti
         </Stack>
         <Stack direction="row" alignItems="center" spacing={1}>
           <MetadataSyncIndicator />
-          <IconButton color="primary" onClick={onRefresh}>
-            <RefreshIcon />
-          </IconButton>
+          {onRefresh && (
+            <IconButton color="primary" onClick={onRefresh}>
+              <RefreshIcon />
+            </IconButton>
+          )}
           {onNewFolder && (
             <Button variant="outlined" onClick={onNewFolder} sx={{ borderStyle: 'dashed' }}>
               Nouveau dossier
             </Button>
           )}
+          <Button
+            component={Link}
+            to="/"
+            color="secondary"
+            variant={!inSettings && !inPages ? 'contained' : 'text'}
+          >
+            Studio
+          </Button>
+          <Button
+            component={Link}
+            to="/pages"
+            color="secondary"
+            variant={inPages ? 'contained' : 'text'}
+          >
+            Pages statiques
+          </Button>
           <Button
             component={Link}
             to={inSettings ? '/' : '/settings'}

--- a/admin/src/pages/App.tsx
+++ b/admin/src/pages/App.tsx
@@ -8,6 +8,7 @@ import { FolderEditor } from '../components/FolderEditor.js';
 import { MediaGrid } from '../components/MediaGrid.js';
 import { MediaEditor } from '../components/MediaEditor.js';
 import { SettingsPage } from './SettingsPage.js';
+import { StaticPagesPage } from './StaticPagesPage.js';
 import { SelectionProvider, useSelection } from '../state/SelectionContext.js';
 import { FolderNode, MediaNode, Settings } from '../api/types.js';
 
@@ -126,6 +127,7 @@ const AppRoutes: React.FC = () => {
   return (
     <Routes>
       <Route path="/" element={<AdminView tree={tree} settings={settings} />} />
+      <Route path="/pages" element={<StaticPagesPage />} />
       <Route path="/settings" element={<SettingsPage settings={settings} />} />
     </Routes>
   );

--- a/admin/src/pages/StaticPagesPage.tsx
+++ b/admin/src/pages/StaticPagesPage.tsx
@@ -1,0 +1,458 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  MenuItem,
+  InputAdornment,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/AddRounded';
+import DeleteIcon from '@mui/icons-material/DeleteOutlineRounded';
+import VisibilityIcon from '@mui/icons-material/VisibilityRounded';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOffRounded';
+import SaveIcon from '@mui/icons-material/SaveRounded';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpwardRounded';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownwardRounded';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesomeRounded';
+import LinkIcon from '@mui/icons-material/LinkRounded';
+
+import { api, useStaticPages } from '../api/client.js';
+import { StaticPage } from '../api/types.js';
+import { Toolbar } from '../components/Toolbar.js';
+import { RichTextEditor } from '../components/RichTextEditor.js';
+
+const createId = () => (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2));
+
+const layoutPresets: Array<{ id: string; label: string; spans: number[] }> = [
+  { id: 'one', label: '1 colonne pleine', spans: [12] },
+  { id: 'two', label: '2 colonnes équilibrées', spans: [6, 6] },
+  { id: 'two-wide', label: '2 colonnes (large + étroite)', spans: [8, 4] },
+  { id: 'three', label: '3 colonnes', spans: [4, 4, 4] }
+];
+
+const clonePage = (page: StaticPage): StaticPage => ({
+  ...page,
+  sections: page.sections.map((section) => ({
+    ...section,
+    columns: section.columns.map((column) => ({ ...column }))
+  }))
+});
+
+const ensureSections = (page: StaticPage): StaticPage => {
+  if (page.sections.length > 0) return page;
+  return {
+    ...page,
+    sections: [
+      {
+        id: createId(),
+        columns: [
+          {
+            id: createId(),
+            span: 12,
+            content: ''
+          }
+        ]
+      }
+    ]
+  };
+};
+
+export const StaticPagesPage: React.FC = () => {
+  const { data: pages, error } = useStaticPages();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<StaticPage | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (pages && pages.length > 0) {
+      if (!selectedId || !pages.some((page) => page.id === selectedId)) {
+        setSelectedId(pages[0].id);
+      }
+    } else {
+      setSelectedId(null);
+      setDraft(null);
+    }
+  }, [pages, selectedId]);
+
+  useEffect(() => {
+    if (!pages || !selectedId) {
+      setDraft(null);
+      setIsDirty(false);
+      return;
+    }
+    const page = pages.find((item) => item.id === selectedId);
+    if (page) {
+      setDraft(ensureSections(clonePage(page)));
+      setIsDirty(false);
+      setErrorMessage(null);
+    }
+  }, [pages, selectedId]);
+
+  const orderedPages = useMemo(() => (pages ? [...pages].sort((a, b) => a.order - b.order) : []), [pages]);
+
+  const handleCreatePage = async () => {
+    const title = window.prompt('Titre de la nouvelle page statique ?')?.trim();
+    try {
+      const created = await api.createStaticPage(title && title.length > 0 ? title : undefined);
+      setSelectedId(created.id);
+    } catch (err) {
+      setErrorMessage((err as Error).message);
+    }
+  };
+
+  const handleDeletePage = async (page: StaticPage) => {
+    if (!window.confirm(`Supprimer définitivement la page « ${page.title} » ?`)) {
+      return;
+    }
+    try {
+      await api.deleteStaticPage(page.id);
+    } catch (err) {
+      setErrorMessage((err as Error).message);
+    }
+  };
+
+  const handleToggleVisibility = async (page: StaticPage) => {
+    try {
+      await api.updateStaticPage(page.id, { visible: !page.visible });
+    } catch (err) {
+      setErrorMessage((err as Error).message);
+    }
+  };
+
+  const updateDraft = (updater: (current: StaticPage) => StaticPage) => {
+    setDraft((current) => {
+      if (!current) return current;
+      const next = updater(current);
+      setIsDirty(true);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!draft) return;
+    setSaving(true);
+    try {
+      await api.updateStaticPage(draft.id, {
+        title: draft.title,
+        slug: draft.slug,
+        visible: draft.visible,
+        order: draft.order,
+        sections: draft.sections
+      });
+      setIsDirty(false);
+      setErrorMessage(null);
+    } catch (err) {
+      setErrorMessage((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRegenerateSlug = () => {
+    if (!draft) return;
+    const base = draft.title
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    updateDraft((current) => ({ ...current, slug: base || 'page-statique' }));
+  };
+
+  const handleAddSection = () => {
+    updateDraft((current) => ({
+      ...current,
+      sections: [
+        ...current.sections,
+        {
+          id: createId(),
+          columns: [
+            {
+              id: createId(),
+              span: 12,
+              content: ''
+            }
+          ]
+        }
+      ]
+    }));
+  };
+
+  const handleRemoveSection = (sectionId: string) => {
+    updateDraft((current) => ({
+      ...current,
+      sections: (() => {
+        const remaining = current.sections.filter((section) => section.id !== sectionId);
+        if (remaining.length > 0) return remaining;
+        return [
+          {
+            id: createId(),
+            columns: [
+              {
+                id: createId(),
+                span: 12,
+                content: ''
+              }
+            ]
+          }
+        ];
+      })()
+    }));
+  };
+
+  const handleLayoutChange = (sectionId: string, spans: number[]) => {
+    updateDraft((current) => ({
+      ...current,
+      sections: current.sections.map((section) => {
+        if (section.id !== sectionId) return section;
+        const nextColumns = spans.map((span, index) => {
+          const existing = section.columns[index];
+          return {
+            id: existing?.id ?? createId(),
+            span,
+            content: existing?.content ?? ''
+          };
+        });
+        return {
+          ...section,
+          columns: nextColumns
+        };
+      })
+    }));
+  };
+
+  const handleColumnContentChange = (sectionId: string, columnId: string, content: string) => {
+    updateDraft((current) => ({
+      ...current,
+      sections: current.sections.map((section) => {
+        if (section.id !== sectionId) return section;
+        return {
+          ...section,
+          columns: section.columns.map((column) => (column.id === columnId ? { ...column, content } : column))
+        };
+      })
+    }));
+  };
+
+  const handleMovePage = async (page: StaticPage, direction: -1 | 1) => {
+    if (!pages) return;
+    const targetOrder = page.order + direction;
+    if (targetOrder < 0 || targetOrder >= pages.length) return;
+    try {
+      await api.updateStaticPage(page.id, { order: targetOrder });
+    } catch (err) {
+      setErrorMessage((err as Error).message);
+    }
+  };
+
+  return (
+    <Stack sx={{ height: '100vh' }}>
+      <Toolbar onRefresh={() => api.refreshStaticPages()} title={draft ? draft.title : 'Pages statiques'} />
+      <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        <Box sx={{ width: 320, borderRight: '1px solid rgba(111,137,166,0.2)', p: 3, overflowY: 'auto' }}>
+          <Stack spacing={2}>
+            <Button variant="outlined" startIcon={<AddIcon />} onClick={handleCreatePage}>
+              Nouvelle page
+            </Button>
+            {error && <Alert severity="error">Impossible de charger les pages statiques.</Alert>}
+            <List dense sx={{ border: '1px solid rgba(111,137,166,0.2)', borderRadius: 2 }}>
+              {orderedPages.map((page) => (
+                <ListItem
+                  key={page.id}
+                  disablePadding
+                  secondaryAction={
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                      <Tooltip title="Monter">
+                        <span>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleMovePage(page, -1)}
+                            disabled={page.order === 0}
+                          >
+                            <ArrowUpwardIcon fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                      <Tooltip title="Descendre">
+                        <span>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleMovePage(page, 1)}
+                            disabled={page.order === orderedPages.length - 1}
+                          >
+                            <ArrowDownwardIcon fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                      <Tooltip title={page.visible ? 'Masquer la page' : 'Publier la page'}>
+                        <IconButton size="small" onClick={() => handleToggleVisibility(page)}>
+                          {page.visible ? <VisibilityIcon fontSize="small" /> : <VisibilityOffIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Supprimer">
+                        <IconButton size="small" onClick={() => handleDeletePage(page)}>
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Stack>
+                  }
+                >
+                  <ListItemButton selected={page.id === selectedId} onClick={() => setSelectedId(page.id)}>
+                    <ListItemText
+                      primary={
+                        <Stack direction="row" spacing={1} alignItems="center">
+                          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                            {page.title}
+                          </Typography>
+                          {!page.visible && <Chip size="small" label="cachée" color="warning" />}
+                        </Stack>
+                      }
+                      secondary={`/${page.slug}`}
+                    />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+              {orderedPages.length === 0 && (
+                <ListItem>
+                  <ListItemText primary="Aucune page statique pour le moment." />
+                </ListItem>
+              )}
+            </List>
+          </Stack>
+        </Box>
+        <Divider orientation="vertical" flexItem />
+        <Box sx={{ flex: 1, overflowY: 'auto', p: 4 }}>
+          {!draft && (
+            <Stack spacing={3} alignItems="center" justifyContent="center" sx={{ mt: 8 }}>
+              <AutoAwesomeIcon color="primary" sx={{ fontSize: 48 }} />
+              <Typography variant="h6" textAlign="center">
+                Sélectionnez une page statique ou créez-en une nouvelle pour commencer.
+              </Typography>
+            </Stack>
+          )}
+          {draft && (
+            <Stack spacing={4}>
+              {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                <TextField
+                  label="Titre"
+                  value={draft.title}
+                  onChange={(event) => updateDraft((current) => ({ ...current, title: event.target.value }))}
+                  fullWidth
+                />
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <Typography component="span" variant="body2">
+                    Visible ?
+                  </Typography>
+                  <Switch
+                    checked={draft.visible}
+                    onChange={(event) => updateDraft((current) => ({ ...current, visible: event.target.checked }))}
+                  />
+                </Stack>
+              </Stack>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                <TextField
+                  label="Slug"
+                  value={draft.slug}
+                  onChange={(event) => updateDraft((current) => ({ ...current, slug: event.target.value }))}
+                  fullWidth
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LinkIcon sx={{ color: 'text.disabled' }} />
+                      </InputAdornment>
+                    )
+                  }}
+                />
+                <Button variant="outlined" onClick={handleRegenerateSlug}>
+                  Régénérer
+                </Button>
+              </Stack>
+
+              <Stack spacing={3}>
+                {draft.sections.map((section, index) => (
+                  <Stack key={section.id} spacing={2} sx={{ border: '1px solid rgba(111,137,166,0.25)', borderRadius: 2, p: 2.5 }}>
+                    <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }}>
+                      <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                        Section {index + 1}
+                      </Typography>
+                      <Select
+                        size="small"
+                        value={layoutPresets.find((preset) =>
+                          preset.spans.length === section.columns.length &&
+                          preset.spans.every((span, idx) => section.columns[idx]?.span === span)
+                        )?.id || 'custom'}
+                        onChange={(event) => {
+                          const preset = layoutPresets.find((item) => item.id === event.target.value);
+                          if (preset) {
+                            handleLayoutChange(section.id, preset.spans);
+                          }
+                        }}
+                        sx={{ minWidth: 220 }}
+                      >
+                        {layoutPresets.map((preset) => (
+                          <MenuItem key={preset.id} value={preset.id}>
+                            {preset.label}
+                          </MenuItem>
+                        ))}
+                        <MenuItem value="custom" disabled>
+                          Disposition personnalisée
+                        </MenuItem>
+                      </Select>
+                      <Box flex={1} />
+                      <Button color="warning" onClick={() => handleRemoveSection(section.id)}>
+                        Supprimer la section
+                      </Button>
+                    </Stack>
+                    <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                      {section.columns.map((column, columnIndex) => (
+                        <Box key={column.id} sx={{ flex: column.span, minWidth: 0 }}>
+                          <RichTextEditor
+                            value={column.content}
+                            onChange={(content) => handleColumnContentChange(section.id, column.id, content)}
+                            placeholder={`Contenu de la colonne ${columnIndex + 1}`}
+                            label={`Colonne ${columnIndex + 1}`}
+                          />
+                        </Box>
+                      ))}
+                    </Stack>
+                  </Stack>
+                ))}
+              </Stack>
+
+              <Stack direction="row" spacing={2}>
+                <Button variant="outlined" onClick={handleAddSection}>
+                  Ajouter une section
+                </Button>
+                <Box flex={1} />
+                <Button
+                  variant="contained"
+                  startIcon={<SaveIcon />}
+                  onClick={handleSave}
+                  disabled={!isDirty || saving}
+                >
+                  {saving ? 'Enregistrement...' : 'Enregistrer la page'}
+                </Button>
+              </Stack>
+            </Stack>
+          )}
+        </Box>
+      </Box>
+    </Stack>
+  );
+};

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -13,6 +13,7 @@ export const METADATA_ROOT = process.env.METADATA_ROOT || path.join(PROJECT_ROOT
 export const FOLDER_META_FILE = path.join(METADATA_ROOT, '.dossier-meta.json');
 export const MEDIA_META_FILE = path.join(MEDIA_ROOT, '.media-meta.json');
 export const SETTINGS_FILE = path.join(METADATA_ROOT, 'settings.json');
+export const STATIC_PAGES_FILE = path.join(METADATA_ROOT, 'pages.json');
 
 export const THUMBNAILS_ROOT = process.env.THUMBNAILS_ROOT || path.join(PROJECT_ROOT, 'thumbnails');
 export const THUMBNAIL_CONFIG_FILE =

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import type { Server } from 'http';
 import apiRouter from './routes/api.js';
 import mediaRouter from './routes/media.js';
 import { metadataStore } from './services/MetadataStore.js';
+import { staticPageStore } from './services/StaticPageStore.js';
 import { thumbnailService } from './services/ThumbnailService.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -63,6 +64,7 @@ app.use((err: unknown, _req: express.Request, res: express.Response, _next: expr
 
 export const startServer = async (): Promise<Server> => {
   await metadataStore.ensureReady();
+  await staticPageStore.ensureReady();
   await thumbnailService.ensureReady();
   await nextApp.prepare();
 

--- a/backend/src/services/StaticPageStore.ts
+++ b/backend/src/services/StaticPageStore.ts
@@ -1,0 +1,209 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { STATIC_PAGES_FILE } from '../config.js';
+import {
+  StaticPage,
+  StaticPageColumn,
+  StaticPageSection,
+  staticPageSchema,
+  staticPagesFileSchema
+} from '../types/staticPages.js';
+
+const DEFAULT_SECTION = (): StaticPageSection => ({
+  id: randomUUID(),
+  columns: [
+    {
+      id: randomUUID(),
+      span: 12,
+      content: ''
+    }
+  ]
+});
+
+const clonePage = (page: StaticPage): StaticPage => ({
+  ...page,
+  sections: page.sections.map((section) => ({
+    ...section,
+    columns: section.columns.map((column) => ({ ...column }))
+  }))
+});
+
+const slugify = (value: string): string => {
+  const normalized = value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || 'page';
+};
+
+interface SectionInput {
+  id?: string;
+  columns?: Array<ColumnInput>;
+}
+
+interface ColumnInput {
+  id?: string;
+  span?: number;
+  content?: string;
+}
+
+interface StaticPageInput {
+  title?: string;
+  slug?: string;
+  visible?: boolean;
+  order?: number;
+  sections?: SectionInput[];
+}
+
+export class StaticPageStore {
+  private cache?: StaticPage[];
+
+  async ensureReady() {
+    try {
+      await fs.access(STATIC_PAGES_FILE);
+    } catch (error) {
+      await fs.mkdir(path.dirname(STATIC_PAGES_FILE), { recursive: true });
+      await fs.writeFile(STATIC_PAGES_FILE, JSON.stringify({ pages: [] }, null, 2), 'utf-8');
+    }
+  }
+
+  private async readFile(): Promise<StaticPage[]> {
+    if (!this.cache) {
+      await this.ensureReady();
+      const content = await fs.readFile(STATIC_PAGES_FILE, 'utf-8');
+      const parsed = staticPagesFileSchema.parse(JSON.parse(content));
+      const sorted = [...parsed.pages]
+        .sort((a, b) => a.order - b.order)
+        .map((page, index) =>
+          staticPageSchema.parse({
+            ...page,
+            order: index,
+            sections: page.sections.length > 0 ? page.sections : [DEFAULT_SECTION()]
+          })
+        );
+      this.cache = sorted;
+    }
+    return this.cache.map(clonePage);
+  }
+
+  private async writeFile(pages: StaticPage[]) {
+    const sorted = [...pages]
+      .sort((a, b) => a.order - b.order)
+      .map((page, index) => staticPageSchema.parse({ ...page, order: index }));
+    await fs.writeFile(STATIC_PAGES_FILE, JSON.stringify({ pages: sorted }, null, 2), 'utf-8');
+    this.cache = sorted;
+  }
+
+  private normalizeColumns(columns?: ColumnInput[]): StaticPageColumn[] {
+    const safeColumns = (columns ?? []).map((column) => ({
+      id: column.id ?? randomUUID(),
+      span: Math.min(12, Math.max(1, Math.round(column.span ?? 12))),
+      content: column.content ?? ''
+    }));
+
+    return safeColumns.length > 0 ? safeColumns : DEFAULT_SECTION().columns;
+  }
+
+  private normalizeSections(sections?: SectionInput[]): StaticPageSection[] {
+    const safeSections = (sections ?? []).map((section) => ({
+      id: section.id ?? randomUUID(),
+      columns: this.normalizeColumns(section.columns)
+    }));
+
+    return safeSections.length > 0 ? safeSections : [DEFAULT_SECTION()];
+  }
+
+  private ensureUniqueSlug(slug: string, pages: StaticPage[], excludeId?: string): string {
+    const base = slugify(slug);
+    let candidate = base;
+    let suffix = 1;
+    const existing = new Set(pages.filter((page) => page.id !== excludeId).map((page) => page.slug));
+    while (existing.has(candidate)) {
+      candidate = `${base}-${suffix++}`;
+    }
+    return candidate;
+  }
+
+  async list(): Promise<StaticPage[]> {
+    return this.readFile();
+  }
+
+  async get(id: string): Promise<StaticPage | undefined> {
+    const pages = await this.readFile();
+    return pages.find((page) => page.id === id);
+  }
+
+  async create(input: StaticPageInput = {}): Promise<StaticPage> {
+    const pages = await this.readFile();
+    const now = new Date().toISOString();
+    const title = input.title?.trim() || 'Nouvelle page';
+    const slug = this.ensureUniqueSlug(input.slug?.trim() || slugify(title), pages);
+
+    const page: StaticPage = staticPageSchema.parse({
+      id: randomUUID(),
+      title,
+      slug,
+      visible: input.visible ?? false,
+      order: pages.length,
+      sections: this.normalizeSections(input.sections),
+      createdAt: now,
+      updatedAt: now
+    });
+
+    await this.writeFile([...pages, page]);
+    return clonePage(page);
+  }
+
+  async update(id: string, input: StaticPageInput): Promise<StaticPage> {
+    const pages = await this.readFile();
+    const index = pages.findIndex((page) => page.id === id);
+    if (index === -1) {
+      throw new Error('Page introuvable');
+    }
+
+    const now = new Date().toISOString();
+    const current = pages[index];
+
+    const nextTitle = input.title?.trim() || current.title;
+    const requestedSlug = input.slug?.trim();
+    const slug = requestedSlug
+      ? this.ensureUniqueSlug(requestedSlug, pages, id)
+      : input.title
+      ? this.ensureUniqueSlug(slugify(nextTitle), pages, id)
+      : current.slug;
+
+    const targetIndex = input.order ?? current.order;
+
+    const nextPage: StaticPage = staticPageSchema.parse({
+      ...current,
+      title: nextTitle,
+      slug,
+      visible: input.visible ?? current.visible,
+      sections: input.sections ? this.normalizeSections(input.sections) : current.sections,
+      order: targetIndex,
+      updatedAt: now
+    });
+
+    const nextPages = [...pages];
+    nextPages.splice(index, 1);
+    const safeIndex = Math.max(0, Math.min(targetIndex, nextPages.length));
+    nextPages.splice(safeIndex, 0, nextPage);
+    await this.writeFile(nextPages);
+    const refreshed = await this.get(id);
+    if (!refreshed) {
+      throw new Error('Page introuvable après mise à jour');
+    }
+    return refreshed;
+  }
+
+  async delete(id: string) {
+    const pages = await this.readFile();
+    const filtered = pages.filter((page) => page.id !== id);
+    await this.writeFile(filtered);
+  }
+}
+
+export const staticPageStore = new StaticPageStore();

--- a/backend/src/types/staticPages.ts
+++ b/backend/src/types/staticPages.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+export const staticPageColumnSchema = z.object({
+  id: z.string(),
+  span: z.number().int().min(1).max(12),
+  content: z.string().default('')
+});
+
+export type StaticPageColumn = z.infer<typeof staticPageColumnSchema>;
+
+export const staticPageSectionSchema = z.object({
+  id: z.string(),
+  columns: z.array(staticPageColumnSchema).min(1)
+});
+
+export type StaticPageSection = z.infer<typeof staticPageSectionSchema>;
+
+export const staticPageSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  slug: z.string(),
+  visible: z.boolean(),
+  order: z.number().int().nonnegative(),
+  sections: z.array(staticPageSectionSchema),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+
+export type StaticPage = z.infer<typeof staticPageSchema>;
+
+export const staticPagesFileSchema = z.object({
+  pages: z.array(staticPageSchema)
+});
+
+export type StaticPagesFile = z.infer<typeof staticPagesFileSchema>;

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -134,6 +134,81 @@ main {
   color: rgba(0, 0, 0, 0.7);
 }
 
+.static-page {
+  max-width: min(960px, 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 6vw, 4rem);
+}
+
+.static-page__header h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.static-page__section {
+  display: block;
+}
+
+.static-page__columns {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: start;
+}
+
+.static-page__column {
+  background: var(--paper);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  padding: clamp(1.25rem, 3vw, 1.85rem);
+  box-shadow: 0 10px 35px rgba(0, 0, 0, 0.05);
+  border-radius: 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+.static-page__column::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 20%, rgba(214, 230, 244, 0.2), transparent 65%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.static-page__column > :first-child {
+  margin-top: 0;
+}
+
+.static-page__column p {
+  margin: 0 0 1rem;
+}
+
+.static-page__column p:last-child {
+  margin-bottom: 0;
+}
+
+.static-page__column h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.35rem, 3vw, 1.65rem);
+  letter-spacing: 0.04em;
+}
+
+.static-page__column ul,
+.static-page__column ol {
+  margin: 0 0 1rem 1.2rem;
+}
+
+.static-page__column blockquote {
+  margin: 0 0 1.2rem;
+  padding: 0.6rem 1rem;
+  background: rgba(13, 71, 161, 0.06);
+  border-left: 3px solid rgba(13, 71, 161, 0.35);
+  font-style: italic;
+}
+
 @media (max-width: 900px) {
   main {
     padding-top: 9.5rem;
@@ -147,5 +222,9 @@ main {
   .site-nav {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .static-page__columns {
+    grid-template-columns: 1fr !important;
   }
 }

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Special_Elite } from "next/font/google";
 
+import { getVisibleStaticPages } from "@/lib/staticPages";
+
 import "./globals.css";
 
 const specialElite = Special_Elite({ subsets: ["latin"], weight: "400" });
@@ -12,11 +14,13 @@ export const metadata: Metadata = {
     "Une promenade poétique dans les peintures, dessins et photographies de l'atelier.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const staticPages = await getVisibleStaticPages();
+
   return (
     <html lang="fr">
       <body className={specialElite.className}>
@@ -30,6 +34,11 @@ export default function RootLayout({
           </div>
           <nav className="site-nav" aria-label="Navigation principale">
             <Link href="/">Explorer</Link>
+            {staticPages.map((page) => (
+              <Link key={page.id} href={`/pages/${page.slug}`}>
+                {page.title}
+              </Link>
+            ))}
             <a href="mailto:contact@atelier.example" rel="noreferrer">
               Écrire
             </a>

--- a/site/app/pages/[slug]/page.tsx
+++ b/site/app/pages/[slug]/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { getStaticPageBySlug } from "@/lib/staticPages";
+
+export const dynamic = "force-dynamic";
+
+type PageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const page = await getStaticPageBySlug(params.slug);
+  if (!page || !page.visible) {
+    return {
+      title: "Page introuvable – Atelier sensible",
+    };
+  }
+
+  return {
+    title: `${page.title} – Atelier sensible`,
+    description: `Page statique de l'atelier : ${page.title}`,
+  };
+}
+
+export default async function StaticPageView({ params }: PageProps) {
+  const page = await getStaticPageBySlug(params.slug);
+
+  if (!page || !page.visible) {
+    notFound();
+  }
+
+  return (
+    <article className="static-page">
+      <header className="static-page__header">
+        <h1>{page.title}</h1>
+      </header>
+      {page.sections.map((section) => {
+        const totalSpan = section.columns.reduce((sum, column) => sum + column.span, 0) || 12;
+        const template = section.columns
+          .map((column) => `${Math.round((column.span / totalSpan) * 10000) / 100}%`)
+          .join(" ");
+        return (
+          <section key={section.id} className="static-page__section">
+            <div className="static-page__columns" style={{ gridTemplateColumns: template }}>
+              {section.columns.map((column) => (
+                <div
+                  key={column.id}
+                  className="static-page__column"
+                  dangerouslySetInnerHTML={{ __html: column.content }}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </article>
+  );
+}

--- a/site/lib/staticPages.ts
+++ b/site/lib/staticPages.ts
@@ -1,0 +1,91 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export type StaticPageColumn = {
+  id: string;
+  span: number;
+  content: string;
+};
+
+export type StaticPageSection = {
+  id: string;
+  columns: StaticPageColumn[];
+};
+
+export type StaticPage = {
+  id: string;
+  title: string;
+  slug: string;
+  visible: boolean;
+  order: number;
+  sections: StaticPageSection[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+const STATIC_PAGES_FILE = path.resolve(process.cwd(), "..", "storage", "pages.json");
+
+const normalizeColumn = (value: any): StaticPageColumn | null => {
+  if (!value || typeof value !== "object") return null;
+  const id = typeof value.id === "string" ? value.id : "";
+  const span = Number.isFinite(value.span) ? Math.min(12, Math.max(1, Math.round(value.span))) : 12;
+  const content = typeof value.content === "string" ? value.content : "";
+  if (!id) return null;
+  return { id, span, content };
+};
+
+const normalizeSection = (value: any): StaticPageSection | null => {
+  if (!value || typeof value !== "object" || !Array.isArray(value.columns)) return null;
+  const id = typeof value.id === "string" ? value.id : "";
+  const columns = value.columns.map(normalizeColumn).filter(Boolean) as StaticPageColumn[];
+  if (!id || columns.length === 0) return null;
+  return { id, columns };
+};
+
+const normalizePage = (value: any): StaticPage | null => {
+  if (!value || typeof value !== "object" || !Array.isArray(value.sections)) return null;
+  const id = typeof value.id === "string" ? value.id : "";
+  const title = typeof value.title === "string" ? value.title : "Page";
+  const slug = typeof value.slug === "string" ? value.slug : "page";
+  const visible = typeof value.visible === "boolean" ? value.visible : false;
+  const order = Number.isFinite(value.order) ? Number(value.order) : 0;
+  const sections = value.sections.map(normalizeSection).filter(Boolean) as StaticPageSection[];
+  const createdAt = typeof value.createdAt === "string" ? value.createdAt : new Date().toISOString();
+  const updatedAt = typeof value.updatedAt === "string" ? value.updatedAt : createdAt;
+  if (!id || sections.length === 0) return null;
+  return { id, title, slug, visible, order, sections, createdAt, updatedAt };
+};
+
+async function readStaticPagesFile(): Promise<StaticPage[]> {
+  try {
+    const raw = await fs.readFile(STATIC_PAGES_FILE, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.pages)) {
+      return [];
+    }
+    return (parsed.pages as any[])
+      .map(normalizePage)
+      .filter(Boolean)
+      .map((page, index) => ({ ...(page as StaticPage), order: index })) as StaticPage[];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function getStaticPages(): Promise<StaticPage[]> {
+  const pages = await readStaticPagesFile();
+  return pages.sort((a, b) => a.order - b.order);
+}
+
+export async function getVisibleStaticPages(): Promise<StaticPage[]> {
+  const pages = await getStaticPages();
+  return pages.filter((page) => page.visible);
+}
+
+export async function getStaticPageBySlug(slug: string): Promise<StaticPage | null> {
+  const pages = await getStaticPages();
+  return pages.find((page) => page.slug === slug) ?? null;
+}


### PR DESCRIPTION
## Summary
- add a static page store, schemas, and API endpoints to persist rich content sections
- expose a full admin UI with WYSIWYG column editor for creating, ordering, and toggling static pages
- render published pages on the public site and surface them in the global navigation

## Testing
- npm --prefix backend run build
- npm --prefix admin run build
- npm --prefix site run build

------
https://chatgpt.com/codex/tasks/task_e_68cc371392a88322bdb0f1351ec1a690