### PR TITLE
Add configurable media lightbox overlay

### DIFF
--- a/admin/src/api/types.ts
+++ b/admin/src/api/types.ts
@@ -93,6 +93,15 @@ export type Settings = {
       duration: number;
       easing: string;
     };
+    lightbox: {
+      overlayColor: string;
+      overlayOpacity: number;
+      overlayBlur: number;
+      backgroundColor: string;
+      borderRadius: number;
+      maxWidth: number;
+      padding: number;
+    };
   };
   previews: {
     enabled: boolean;

--- a/admin/src/pages/SettingsPage.tsx
+++ b/admin/src/pages/SettingsPage.tsx
@@ -126,6 +126,158 @@ export const SettingsPage: React.FC<Props> = ({ settings }) => {
                   />
                 </Grid>
               </Grid>
+              <Divider sx={{ my: 3 }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+                Lightbox
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Couleur de l'overlay"
+                    type="color"
+                    value={draft.ui.lightbox.overlayColor}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        ui: {
+                          ...draft.ui,
+                          lightbox: { ...draft.ui.lightbox, overlayColor: event.target.value }
+                        }
+                      })
+                    }
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Opacité de l'overlay"
+                    type="number"
+                    value={draft.ui.lightbox.overlayOpacity}
+                    inputProps={{ min: 0, max: 1, step: 0.05 }}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      setDraft({
+                        ...draft,
+                        ui: {
+                          ...draft.ui,
+                          lightbox: {
+                            ...draft.ui.lightbox,
+                            overlayOpacity: Number.isNaN(value)
+                              ? draft.ui.lightbox.overlayOpacity
+                              : value
+                          }
+                        }
+                      });
+                    }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Flou de l'overlay (px)"
+                    type="number"
+                    value={draft.ui.lightbox.overlayBlur}
+                    inputProps={{ min: 0, max: 96, step: 1 }}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      setDraft({
+                        ...draft,
+                        ui: {
+                          ...draft.ui,
+                          lightbox: {
+                            ...draft.ui.lightbox,
+                            overlayBlur: Number.isNaN(value) ? draft.ui.lightbox.overlayBlur : value
+                          }
+                        }
+                      });
+                    }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Fond de la carte"
+                    type="color"
+                    value={draft.ui.lightbox.backgroundColor}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        ui: {
+                          ...draft.ui,
+                          lightbox: { ...draft.ui.lightbox, backgroundColor: event.target.value }
+                        }
+                      })
+                    }
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Rayon des bords (px)"
+                    type="number"
+                    value={draft.ui.lightbox.borderRadius}
+                    inputProps={{ min: 0, max: 96, step: 1 }}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      setDraft({
+                        ...draft,
+                        ui: {
+                          ...draft.ui,
+                          lightbox: {
+                            ...draft.ui.lightbox,
+                            borderRadius: Number.isNaN(value) ? draft.ui.lightbox.borderRadius : value
+                          }
+                        }
+                      });
+                    }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Largeur maximale (px)"
+                    type="number"
+                    value={draft.ui.lightbox.maxWidth}
+                    inputProps={{ min: 240, max: 2000, step: 10 }}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      setDraft({
+                        ...draft,
+                        ui: {
+                          ...draft.ui,
+                          lightbox: {
+                            ...draft.ui.lightbox,
+                            maxWidth: Number.isNaN(value) ? draft.ui.lightbox.maxWidth : value
+                          }
+                        }
+                      });
+                    }}
+                    fullWidth
+                  />
+                </Grid>
+                <Grid item xs={12} md={4}>
+                  <TextField
+                    label="Marge intérieure (px)"
+                    type="number"
+                    value={draft.ui.lightbox.padding}
+                    inputProps={{ min: 12, max: 160, step: 1 }}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      setDraft({
+                        ...draft,
+                        ui: {
+                          ...draft.ui,
+                          lightbox: {
+                            ...draft.ui.lightbox,
+                            padding: Number.isNaN(value) ? draft.ui.lightbox.padding : value
+                          }
+                        }
+                      });
+                    }}
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
             </CardContent>
           </Card>
 

--- a/backend/src/types/metadata.ts
+++ b/backend/src/types/metadata.ts
@@ -92,9 +92,42 @@ export const settingsSchema = z.object({
           duration: z.number().default(240),
           easing: z.string().default('ease-in-out')
         })
-        .default({ duration: 240, easing: 'ease-in-out' })
+        .default({ duration: 240, easing: 'ease-in-out' }),
+      lightbox: z
+        .object({
+          overlayColor: z.string().default('#ffffff'),
+          overlayOpacity: z.number().min(0).max(1).default(0.92),
+          overlayBlur: z.number().min(0).max(96).default(16),
+          backgroundColor: z.string().default('#f8f4ef'),
+          borderRadius: z.number().min(0).max(96).default(22),
+          maxWidth: z.number().min(240).max(2000).default(980),
+          padding: z.number().min(12).max(160).default(32)
+        })
+        .default({
+          overlayColor: '#ffffff',
+          overlayOpacity: 0.92,
+          overlayBlur: 16,
+          backgroundColor: '#f8f4ef',
+          borderRadius: 22,
+          maxWidth: 980,
+          padding: 32
+        })
     })
-    .default({ theme: 'dawn', accentColor: '#8c6b4f', paperColor: '#f5ede2' }),
+    .default({
+      theme: 'dawn',
+      accentColor: '#8c6b4f',
+      paperColor: '#f5ede2',
+      animation: { duration: 240, easing: 'ease-in-out' },
+      lightbox: {
+        overlayColor: '#ffffff',
+        overlayOpacity: 0.92,
+        overlayBlur: 16,
+        backgroundColor: '#f8f4ef',
+        borderRadius: 22,
+        maxWidth: 980,
+        padding: 32
+      }
+    }),
   previews: z
     .object({
       enabled: z.boolean().default(true),

--- a/site/app/[[...slug]]/page.tsx
+++ b/site/app/[[...slug]]/page.tsx
@@ -80,9 +80,16 @@ export default async function MediaPage({ params }: PageProps) {
         }
       : undefined;
     const originalPath = encodeForMediaPath(file.pathSegments);
-    const fullPath = thumbnails?.full?.defaultPath
-      ? `/api/media${thumbnails.full.defaultPath}`
-      : `/api/media/${originalPath}`;
+    const fullEntry = thumbnails?.full;
+    const fullImage = fullEntry
+      ? {
+          defaultPath: fullEntry.defaultPath,
+          width: fullEntry.width ?? meta?.width,
+          height: fullEntry.height ?? meta?.height,
+          sources: fullEntry.sources.map((source) => ({ format: source.format, path: source.path })),
+        }
+      : undefined;
+    const fullPath = fullEntry?.defaultPath ? `/api/media${fullEntry.defaultPath}` : `/api/media/${originalPath}`;
 
     return {
       id: file.href,
@@ -90,6 +97,18 @@ export default async function MediaPage({ params }: PageProps) {
       mediaPath: originalPath,
       href: fullPath,
       image,
+      fullImage,
+      description: meta?.description,
+      attributes: meta?.attributes,
+      tags: meta?.tags,
+      meta: meta
+        ? {
+            width: meta.width,
+            height: meta.height,
+            orientation: meta.orientation,
+            createdAt: meta.createdAt,
+          }
+        : undefined,
     };
   });
 

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Special_Elite } from "next/font/google";
 
+import { LightboxProvider } from "@/components/LightboxProvider";
 import { getVisibleStaticPages } from "@/lib/staticPages";
+import { getSettings } from "@/lib/settings";
 
 import "./globals.css";
 
@@ -20,31 +22,34 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const staticPages = await getVisibleStaticPages();
+  const settings = await getSettings();
 
   return (
     <html lang="fr">
       <body className={specialElite.className}>
-        <header className="site-header">
-          <Link href="/" className="site-logo" aria-label="Retour à l'accueil">
-            SJ
-          </Link>
-          <div className="site-title">
-            <h1>Atelier sensible</h1>
-            <p>Fragments de couleur, traits rapides, photographies en murmure.</p>
-          </div>
-          <nav className="site-nav" aria-label="Navigation principale">
-            <Link href="/">Explorer</Link>
-            {staticPages.map((page) => (
-              <Link key={page.id} href={`/pages/${page.slug}`}>
-                {page.title}
-              </Link>
-            ))}
-            <a href="mailto:contact@atelier.example" rel="noreferrer">
-              Écrire
-            </a>
-          </nav>
-        </header>
-        <main>{children}</main>
+        <LightboxProvider lightbox={settings.ui.lightbox} attributeTypes={settings.attributeTypes}>
+          <header className="site-header">
+            <Link href="/" className="site-logo" aria-label="Retour à l'accueil">
+              SJ
+            </Link>
+            <div className="site-title">
+              <h1>Atelier sensible</h1>
+              <p>Fragments de couleur, traits rapides, photographies en murmure.</p>
+            </div>
+            <nav className="site-nav" aria-label="Navigation principale">
+              <Link href="/">Explorer</Link>
+              {staticPages.map((page) => (
+                <Link key={page.id} href={`/pages/${page.slug}`}>
+                  {page.title}
+                </Link>
+              ))}
+              <a href="mailto:contact@atelier.example" rel="noreferrer">
+                Écrire
+              </a>
+            </nav>
+          </header>
+          <main>{children}</main>
+        </LightboxProvider>
       </body>
     </html>
   );

--- a/site/components/GalleryStack.tsx
+++ b/site/components/GalleryStack.tsx
@@ -4,28 +4,63 @@ import { motion } from "framer-motion";
 import clsx from "clsx";
 import Image from "next/image";
 
+import type { AttributeRecord } from "@/types/metadata";
+
+import { useLightbox } from "./LightboxProvider";
 import paperStyles from "./Paper.module.css";
 import styles from "./GalleryStack.module.css";
 
-type GalleryItem = {
+type GalleryImage = {
+  defaultPath: string;
+  width?: number;
+  height?: number;
+  sources: Array<{ format: string; path: string }>;
+};
+
+type GalleryMeta = {
+  width?: number;
+  height?: number;
+  orientation?: string;
+  createdAt?: string;
+};
+
+export type GalleryItem = {
   id: string;
   label: string;
   mediaPath?: string;
   href?: string;
   hints?: string[];
-  image?: {
-    defaultPath: string;
-    width?: number;
-    height?: number;
-    sources: Array<{ format: string; path: string }>;
-  };
+  image?: GalleryImage;
+  fullImage?: GalleryImage;
+  description?: string;
+  attributes?: AttributeRecord;
+  tags?: string[];
+  meta?: GalleryMeta;
 };
 
 type GalleryStackProps = {
   items: GalleryItem[];
 };
 
+function ensureMediaPath(path: string) {
+  if (!path) {
+    return path;
+  }
+
+  if (path.startsWith("http")) {
+    return path;
+  }
+
+  if (path.startsWith("/api/media")) {
+    return path;
+  }
+
+  return `/api/media${path.startsWith("/") ? path : `/${path}`}`;
+}
+
 export function GalleryStack({ items }: GalleryStackProps) {
+  const { open } = useLightbox();
+
   if (items.length === 0) {
     return <p className={styles.empty}>Aucun média pour le moment dans cette alcôve.</p>;
   }
@@ -35,9 +70,80 @@ export function GalleryStack({ items }: GalleryStackProps) {
       {items.map((item, index) => {
         const rotation = index % 2 === 0 ? -1.6 : 1.4;
         const linkHref = item.href ?? (item.mediaPath ? `/api/media/${item.mediaPath}` : "#");
-        const linkProps = item.mediaPath
-          ? { target: "_blank" as const, rel: "noreferrer" }
-          : {};
+
+        const openLightbox = (anchor: HTMLAnchorElement) => {
+          const media = item.fullImage ?? item.image;
+          const defaultPath = media?.defaultPath
+            ? ensureMediaPath(media.defaultPath)
+            : item.mediaPath
+            ? ensureMediaPath(item.mediaPath)
+            : null;
+
+          if (!defaultPath) {
+            return;
+          }
+
+          const sources = media?.sources?.map((source) => ({
+            format: source.format,
+            path: ensureMediaPath(source.path),
+          }));
+
+          const imageElement = anchor.querySelector("img");
+          const rect = imageElement?.getBoundingClientRect();
+
+          const width = media?.width ?? item.meta?.width;
+          const height = media?.height ?? item.meta?.height;
+
+          open({
+            id: item.id,
+            label: item.label,
+            alt: item.label,
+            fullImage: {
+              defaultPath,
+              width,
+              height,
+              sources,
+            },
+            description: item.description,
+            attributes: item.attributes,
+            tags: item.tags,
+            meta: item.meta,
+            origin: rect
+              ? {
+                  left: rect.left,
+                  top: rect.top,
+                  width: rect.width,
+                  height: rect.height,
+                }
+              : undefined,
+          });
+        };
+
+        const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+          if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
+          }
+
+          if (!item.mediaPath && !item.fullImage && !item.image) {
+            return;
+          }
+
+          event.preventDefault();
+          openLightbox(event.currentTarget);
+        };
+
+        const handleKeyDown = (event: React.KeyboardEvent<HTMLAnchorElement>) => {
+          if (event.key !== "Enter" && event.key !== " ") {
+            return;
+          }
+
+          if (!item.mediaPath && !item.fullImage && !item.image) {
+            return;
+          }
+
+          event.preventDefault();
+          openLightbox(event.currentTarget);
+        };
 
         return (
           <motion.li
@@ -45,24 +151,26 @@ export function GalleryStack({ items }: GalleryStackProps) {
             layout
             whileHover={{ rotate: rotation * 0.6, y: -8 }}
             transition={{ type: "spring", stiffness: 180, damping: 18 }}
+          >
+            <a
+              className={clsx(paperStyles.base, paperStyles.gallery, paperStyles.stack, styles.card)}
+              href={linkHref}
+              onClick={handleClick}
+              onKeyDown={handleKeyDown}
+              aria-haspopup={item.mediaPath || item.fullImage || item.image ? "dialog" : undefined}
             >
-              <a
-                className={clsx(paperStyles.base, paperStyles.gallery, paperStyles.stack, styles.card)}
-                href={linkHref}
-                {...linkProps}
-              >
-                <div className={styles.frame}>
-                  {item.image ? (
-                    <picture>
-                      {item.image.sources.map((source) => (
+              <div className={styles.frame}>
+                {item.image ? (
+                  <picture>
+                    {item.image.sources.map((source) => (
                         <source
                           key={`${item.id}-${source.format}`}
-                          srcSet={`/api/media${source.path}`}
+                          srcSet={ensureMediaPath(source.path)}
                           type={`image/${source.format}`}
                         />
                       ))}
                       <Image
-                        src={`/api/media${item.image.defaultPath}`}
+                        src={ensureMediaPath(item.image.defaultPath)}
                         alt={item.label}
                         width={item.image.width ?? 320}
                         height={item.image.height ?? 240}
@@ -74,7 +182,7 @@ export function GalleryStack({ items }: GalleryStackProps) {
                     </picture>
                   ) : item.mediaPath ? (
                     <Image
-                      src={`/api/media/${item.mediaPath}`}
+                      src={ensureMediaPath(item.mediaPath)}
                       alt={item.label}
                       width={320}
                       height={240}

--- a/site/components/Lightbox.module.css
+++ b/site/components/Lightbox.module.css
@@ -1,0 +1,269 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--lightbox-padding, 32px);
+  background: var(--lightbox-overlay, rgba(255, 255, 255, 0.92));
+  backdrop-filter: blur(var(--lightbox-blur, 16px));
+  -webkit-backdrop-filter: blur(var(--lightbox-blur, 16px));
+}
+
+.container {
+  position: relative;
+  width: min(var(--lightbox-max-width, 980px), 100%);
+  max-height: calc(100vh - var(--lightbox-padding, 32px) * 2);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: var(--ink);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 0.5rem 0.25rem 0.5rem 0.5rem;
+}
+
+.container::-webkit-scrollbar {
+  width: 8px;
+}
+
+.container::-webkit-scrollbar-thumb {
+  background: rgba(20, 20, 20, 0.18);
+  border-radius: 999px;
+}
+
+.figureWrapper {
+  position: relative;
+  padding-right: 0.25rem;
+}
+
+.figure {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--lightbox-radius, 22px);
+  background: var(--lightbox-background, #f8f4ef);
+  box-shadow: 0 28px 38px -24px rgba(15, 15, 15, 0.45);
+  cursor: zoom-out;
+}
+
+.picture,
+.image {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.caption {
+  margin: 0.85rem 0 0;
+  text-align: center;
+  font-size: 1.06rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.closeButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(50%, -50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid rgba(24, 24, 24, 0.16);
+  background: rgba(255, 255, 255, 0.92);
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  color: inherit;
+}
+
+.closeButton:hover,
+.closeButton:focus-visible {
+  transform: translate(50%, -50%) scale(1.05);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.18);
+  outline: none;
+}
+
+.detailsPaper {
+  position: relative;
+  padding: 1.6rem 1.9rem;
+  background: var(--lightbox-background, #f8f4ef);
+  border: 1px solid rgba(24, 24, 24, 0.16);
+  border-radius: calc(var(--lightbox-radius, 22px) * 0.82);
+  box-shadow: 0 22px 35px -24px rgba(0, 0, 0, 0.35);
+  clip-path: polygon(3% 2%, 97% 0%, 100% 18%, 97% 98%, 6% 100%, 1% 88%, 0% 10%);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.detailsPaper::before,
+.detailsPaper::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.detailsPaper::before {
+  background-image: linear-gradient(140deg, rgba(11, 74, 111, 0.07), rgba(192, 70, 60, 0.06));
+  opacity: 0.75;
+  mix-blend-mode: multiply;
+}
+
+.detailsPaper::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 120 120'%3E%3Cpath fill='rgba(0,0,0,0.04)' d='M22 20h2v2h-2zM60 58h2v2h-2zM98 96h2v2h-2zM10 84h1.5v1.5H10zM78 18h1.5v1.5H78zM32 106h1.5v1.5H32z'/%3E%3C/svg%3E");
+  opacity: 0.35;
+  mix-blend-mode: multiply;
+}
+
+.description {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.6;
+  white-space: pre-line;
+}
+
+.attributes {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .attributes {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+.attribute {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.attributeTitle {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.attributeValue {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.multiline {
+  white-space: pre-line;
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--accent-blue, #0b4a6f);
+  font-weight: 500;
+}
+
+.colorSwatch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.colorPreview {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.12);
+}
+
+.tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.92rem;
+}
+
+.tag {
+  padding: 0.1rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(11, 74, 111, 0.08);
+  border: 1px solid rgba(11, 74, 111, 0.15);
+}
+
+.loadingOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(248, 244, 239, 0.45);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition: opacity 0.3s ease;
+}
+
+.loadingHidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (max-width: 720px) {
+  .overlay {
+    padding: clamp(16px, 5vw, 28px);
+    align-items: stretch;
+  }
+
+  .container {
+    width: 100%;
+    max-height: none;
+    height: 100%;
+    padding: 0;
+    gap: 1.25rem;
+  }
+
+  .figureWrapper {
+    padding: 0 clamp(12px, 4vw, 20px);
+  }
+
+  .closeButton {
+    position: fixed;
+    top: clamp(12px, 4vw, 20px);
+    right: clamp(12px, 4vw, 20px);
+    transform: none;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.15);
+    z-index: 2;
+  }
+
+  .closeButton:hover,
+  .closeButton:focus-visible {
+    transform: scale(1.05);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay {
+    transition: none;
+  }
+
+  .closeButton {
+    transition: none;
+  }
+
+  .loadingOverlay {
+    transition: none;
+  }
+}

--- a/site/components/LightboxProvider.tsx
+++ b/site/components/LightboxProvider.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import clsx from "clsx";
+
+import type { AttributeRecord, AttributeType, AttributeValue } from "@/types/metadata";
+import type { LightboxSettings } from "@/lib/settings";
+import styles from "./Lightbox.module.css";
+
+type LightboxImageSource = {
+  format: string;
+  path: string;
+};
+
+type LightboxImage = {
+  defaultPath: string;
+  width?: number;
+  height?: number;
+  sources?: LightboxImageSource[];
+};
+
+type LightboxMeta = {
+  width?: number;
+  height?: number;
+  orientation?: string;
+  createdAt?: string;
+};
+
+type LightboxPayload = {
+  id: string;
+  label: string;
+  alt: string;
+  fullImage: LightboxImage;
+  previewSrc?: string;
+  description?: string;
+  attributes?: AttributeRecord;
+  tags?: string[];
+  meta?: LightboxMeta;
+  origin?: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  };
+};
+
+type LightboxContextValue = {
+  open: (payload: LightboxPayload) => void;
+  close: () => void;
+};
+
+const LightboxContext = createContext<LightboxContextValue | null>(null);
+
+export function useLightbox() {
+  const context = useContext(LightboxContext);
+  if (!context) {
+    throw new Error("useLightbox must be used within a LightboxProvider");
+  }
+  return context;
+}
+
+type LightboxProviderProps = {
+  children: ReactNode;
+  lightbox: LightboxSettings;
+  attributeTypes: AttributeType[];
+};
+
+type DisplayAttribute = {
+  id: string;
+  label: string;
+  content: ReactNode;
+};
+
+function withOpacity(color: string, opacity: number) {
+  const normalized = Math.min(1, Math.max(0, opacity));
+
+  if (color.startsWith("#")) {
+    const hex = color.slice(1);
+    const size = hex.length === 3 ? 1 : 2;
+    const parse = (offset: number) => {
+      const chunk = hex.slice(offset * size, offset * size + size);
+      const value = size === 1 ? parseInt(chunk.repeat(2), 16) : parseInt(chunk, 16);
+      return Number.isFinite(value) ? value : 255;
+    };
+    const r = parse(0);
+    const g = parse(1);
+    const b = parse(2);
+    return `rgba(${r}, ${g}, ${b}, ${normalized})`;
+  }
+
+  const rgbMatch = color.match(/rgb\s*\(([^)]+)\)/i) || color.match(/rgba\s*\(([^)]+)\)/i);
+  if (rgbMatch) {
+    const [r = "255", g = "255", b = "255"] = rgbMatch[1]
+      .split(",")
+      .map((value) => value.trim());
+    return `rgba(${Number(r)}, ${Number(g)}, ${Number(b)}, ${normalized})`;
+  }
+
+  return `rgba(255, 255, 255, ${normalized})`;
+}
+
+function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat("fr-FR", { dateStyle: "long" }).format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function renderAttributeValue(value: AttributeValue): ReactNode {
+  switch (value.type) {
+    case "text":
+      return <span>{value.value}</span>;
+    case "textarea":
+      return <span className={styles.multiline}>{value.value}</span>;
+    case "boolean":
+      return <span>{value.value ? "Oui" : "Non"}</span>;
+    case "date":
+      return <span>{formatDate(value.value)}</span>;
+    case "number":
+      return <span>{Number(value.value).toLocaleString("fr-FR")}</span>;
+    case "link":
+      return (
+        <a className={styles.link} href={value.value.url} target="_blank" rel="noreferrer">
+          {value.value.label ?? value.value.url}
+        </a>
+      );
+    case "image":
+      return (
+        <a className={styles.link} href={`/api/media/${value.value}`} target="_blank" rel="noreferrer">
+          Voir l’image
+        </a>
+      );
+    case "select":
+      return <span>{value.value}</span>;
+    case "color":
+      return (
+        <span className={styles.colorSwatch}>
+          <span className={styles.colorPreview} style={{ background: value.value }} />
+          <span>{value.value}</span>
+        </span>
+      );
+    default:
+      return <span>{String((value as AttributeValue & { value: unknown }).value ?? "")}</span>;
+  }
+}
+
+function buildAttributes(
+  attributes: AttributeRecord | undefined,
+  labelMap: Record<string, AttributeType>,
+  meta: LightboxMeta | undefined,
+  tags: string[] | undefined,
+): DisplayAttribute[] {
+  const entries: DisplayAttribute[] = [];
+
+  if (attributes) {
+    for (const [key, value] of Object.entries(attributes)) {
+      const label = labelMap[key]?.label ?? key;
+      entries.push({
+        id: key,
+        label,
+        content: renderAttributeValue(value),
+      });
+    }
+  }
+
+  if (meta?.width && meta?.height) {
+    entries.push({
+      id: "dimensions",
+      label: "Dimensions",
+      content: `${meta.width.toLocaleString("fr-FR")} × ${meta.height.toLocaleString("fr-FR")} px`,
+    });
+  }
+
+  if (meta?.orientation) {
+    const orientationLabels: Record<string, string> = {
+      horizontal: "Paysage",
+      vertical: "Portrait",
+      square: "Carré",
+    };
+    entries.push({
+      id: "orientation",
+      label: "Orientation",
+      content: orientationLabels[meta.orientation] ?? meta.orientation,
+    });
+  }
+
+  if (meta?.createdAt) {
+    entries.push({
+      id: "createdAt",
+      label: "Créé",
+      content: formatDate(meta.createdAt),
+    });
+  }
+
+  if (tags && tags.length > 0) {
+    entries.push({
+      id: "tags",
+      label: "Mots-clés",
+      content: (
+        <span className={styles.tags}>
+          {tags.map((tag) => (
+            <span key={tag} className={styles.tag}>
+              {tag}
+            </span>
+          ))}
+        </span>
+      ),
+    });
+  }
+
+  return entries;
+}
+
+export function LightboxProvider({ children, lightbox, attributeTypes }: LightboxProviderProps) {
+  const [item, setItem] = useState<LightboxPayload | null>(null);
+  const [portalNode, setPortalNode] = useState<HTMLElement | null>(null);
+  const [viewport, setViewport] = useState({ width: 0, height: 0 });
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const shouldReduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    setPortalNode(document.body);
+  }, []);
+
+  const open = useCallback((payload: LightboxPayload) => {
+    setItem(payload);
+  }, []);
+
+  const close = useCallback(() => {
+    setItem(null);
+  }, []);
+
+  useEffect(() => {
+    if (!item) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        close();
+      }
+    };
+
+    const updateViewport = () => {
+      setViewport({ width: window.innerWidth, height: window.innerHeight });
+    };
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+    updateViewport();
+    window.addEventListener("resize", updateViewport);
+    setImageLoaded(false);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", updateViewport);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [item, close]);
+
+  useEffect(() => {
+    if (item && closeButtonRef.current) {
+      closeButtonRef.current.focus({ preventScroll: true });
+    }
+  }, [item]);
+
+  useEffect(() => {
+    if (!item) {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      setImageLoaded(true);
+    }, 1200);
+    return () => window.clearTimeout(timeout);
+  }, [item]);
+
+  const overlayStyle = useMemo(() => {
+    const style: CSSProperties = {
+      ["--lightbox-overlay" as string]: withOpacity(lightbox.overlayColor, lightbox.overlayOpacity),
+      ["--lightbox-blur" as string]: `${lightbox.overlayBlur}px`,
+      ["--lightbox-background" as string]: lightbox.backgroundColor,
+      ["--lightbox-radius" as string]: `${lightbox.borderRadius}px`,
+      ["--lightbox-max-width" as string]: `${lightbox.maxWidth}px`,
+      ["--lightbox-padding" as string]: `${lightbox.padding}px`,
+    };
+    return style;
+  }, [lightbox]);
+
+  const animationTarget = useMemo(() => {
+    if (!item || viewport.width === 0 || viewport.height === 0) {
+      return null;
+    }
+
+    const padding = lightbox.padding * 2;
+    const maxWidth = Math.min(lightbox.maxWidth, viewport.width - padding);
+    const aspectRatio =
+      item.fullImage.width && item.fullImage.height
+        ? item.fullImage.width / item.fullImage.height
+        : null;
+
+    let width = Math.max(240, maxWidth);
+    let height = aspectRatio ? width / aspectRatio : width * 0.75;
+
+    const maxHeight = viewport.height - padding - 160;
+    if (height > maxHeight) {
+      height = maxHeight;
+      width = aspectRatio ? height * aspectRatio : width;
+    }
+
+    return { width, height };
+  }, [item, viewport, lightbox]);
+
+  const figureAnimation = useMemo(() => {
+    if (!item || shouldReduceMotion) {
+      return {
+        initial: { opacity: 0, scale: 0.92 },
+        animate: { opacity: 1, scale: 1 },
+        exit: { opacity: 0, scale: 0.92 },
+      } as const;
+    }
+
+    if (!item.origin || !animationTarget) {
+      return {
+        initial: { opacity: 0, scale: 0.92 },
+        animate: { opacity: 1, scale: 1 },
+        exit: { opacity: 0, scale: 0.92 },
+      } as const;
+    }
+
+    const centerX = item.origin.left + item.origin.width / 2 - viewport.width / 2;
+    const centerY = item.origin.top + item.origin.height / 2 - viewport.height / 2;
+    const scaleX = item.origin.width / animationTarget.width;
+    const scaleY = item.origin.height / animationTarget.height;
+
+    return {
+      initial: { opacity: 0, x: centerX, y: centerY, scaleX, scaleY },
+      animate: { opacity: 1, x: 0, y: 0, scaleX: 1, scaleY: 1 },
+      exit: { opacity: 0, x: centerX * 0.6, y: centerY * 0.6, scaleX: scaleX * 0.9, scaleY: scaleY * 0.9 },
+    } as const;
+  }, [item, animationTarget, viewport, shouldReduceMotion]);
+
+  const attributeLabelMap = useMemo(() => {
+    return attributeTypes.reduce<Record<string, AttributeType>>((acc, type) => {
+      acc[type.id] = type;
+      return acc;
+    }, {});
+  }, [attributeTypes]);
+
+  const attributeEntries = useMemo(() => {
+    if (!item) {
+      return [];
+    }
+    return buildAttributes(item.attributes, attributeLabelMap, item.meta, item.tags);
+  }, [item, attributeLabelMap]);
+
+  const contextValue = useMemo(() => ({ open, close }), [open, close]);
+
+  if (!portalNode) {
+    return <LightboxContext.Provider value={contextValue}>{children}</LightboxContext.Provider>;
+  }
+
+  return (
+    <LightboxContext.Provider value={contextValue}>
+      {children}
+      {createPortal(
+        <AnimatePresence>
+          {item && (
+            <motion.div
+              className={styles.overlay}
+              style={overlayStyle}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: shouldReduceMotion ? 0 : 0.22, ease: "easeOut" }}
+              onClick={close}
+            >
+              <motion.div
+                className={styles.container}
+                role="dialog"
+                aria-modal="true"
+                aria-label={item.label}
+                initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 18 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: shouldReduceMotion ? 0 : 18 }}
+                transition={{ duration: shouldReduceMotion ? 0 : 0.25, ease: "easeOut" }}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <button
+                  ref={closeButtonRef}
+                  type="button"
+                  className={styles.closeButton}
+                  aria-label="Fermer la visionneuse"
+                  onClick={close}
+                >
+                  ×
+                </button>
+                <div className={styles.figureWrapper}>
+                  <motion.figure
+                    className={styles.figure}
+                    initial={figureAnimation.initial}
+                    animate={figureAnimation.animate}
+                    exit={figureAnimation.exit}
+                    transition={{ type: "spring", stiffness: 220, damping: 26 }}
+                    onClick={close}
+                  >
+                    <picture className={styles.picture}>
+                      {item.fullImage.sources?.map((source) => (
+                        <source key={`${item.id}-${source.format}`} srcSet={source.path} type={`image/${source.format}`} />
+                      ))}
+                      <img
+                        src={item.fullImage.defaultPath}
+                        alt={item.alt}
+                        className={styles.image}
+                        width={item.fullImage.width}
+                        height={item.fullImage.height}
+                        onLoad={() => setImageLoaded(true)}
+                        loading="eager"
+                        draggable={false}
+                      />
+                    </picture>
+                    <div
+                      className={clsx(styles.loadingOverlay, imageLoaded && styles.loadingHidden)}
+                      aria-hidden={imageLoaded}
+                    >
+                      <span>Chargement…</span>
+                    </div>
+                  </motion.figure>
+                  <p className={styles.caption}>{item.label}</p>
+                </div>
+                {(item.description || attributeEntries.length > 0) && (
+                  <div className={styles.detailsPaper}>
+                    {item.description && <p className={styles.description}>{item.description}</p>}
+                    {attributeEntries.length > 0 && (
+                      <div className={styles.attributes}>
+                        {attributeEntries.map((entry) => (
+                          <div key={entry.id} className={styles.attribute}>
+                            <span className={styles.attributeTitle}>{entry.label}</span>
+                            <span className={styles.attributeValue}>{entry.content}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </motion.div>
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        portalNode,
+      )}
+    </LightboxContext.Provider>
+  );
+}

--- a/site/components/NavigationScene.tsx
+++ b/site/components/NavigationScene.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import clsx from "clsx";
 
 import { CategoryList } from "./CategoryList";
-import { GalleryStack } from "./GalleryStack";
+import { GalleryStack, type GalleryItem } from "./GalleryStack";
 import { SelectionStack } from "./SelectionStack";
 import styles from "./NavigationScene.module.css";
 
@@ -14,20 +14,6 @@ type StackItem = {
 };
 
 type CategoryItem = StackItem;
-
-type GalleryItem = {
-  id: string;
-  label: string;
-  mediaPath?: string;
-  href?: string;
-  hints?: string[];
-  image?: {
-    defaultPath: string;
-    width?: number;
-    height?: number;
-    sources: Array<{ format: string; path: string }>;
-  };
-};
 
 type NavigationSceneProps = {
   root: StackItem;

--- a/site/lib/settings.ts
+++ b/site/lib/settings.ts
@@ -1,0 +1,163 @@
+import { cache } from "react";
+import { promises as fs } from "fs";
+import path from "path";
+
+import type { AttributeType } from "@/types/metadata";
+
+export type LightboxSettings = {
+  overlayColor: string;
+  overlayOpacity: number;
+  overlayBlur: number;
+  backgroundColor: string;
+  borderRadius: number;
+  maxWidth: number;
+  padding: number;
+};
+
+export type SiteSettings = {
+  attributeTypes: AttributeType[];
+  ui: {
+    theme: string;
+    accentColor: string;
+    paperColor: string;
+    texture?: string;
+    animation: {
+      duration: number;
+      easing: string;
+    };
+    lightbox: LightboxSettings;
+  };
+};
+
+const SETTINGS_FILE = path.resolve(process.cwd(), "..", "storage", "settings.json");
+
+const defaultLightbox: LightboxSettings = {
+  overlayColor: "#ffffff",
+  overlayOpacity: 0.92,
+  overlayBlur: 16,
+  backgroundColor: "#f8f4ef",
+  borderRadius: 22,
+  maxWidth: 980,
+  padding: 32,
+};
+
+const defaultSettings: SiteSettings = {
+  attributeTypes: [],
+  ui: {
+    theme: "dawn",
+    accentColor: "#8c6b4f",
+    paperColor: "#f5ede2",
+    animation: {
+      duration: 240,
+      easing: "ease-in-out",
+    },
+    lightbox: defaultLightbox,
+  },
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function isObject(value: unknown): value is UnknownRecord {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeAttributeTypes(input: unknown): AttributeType[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input
+    .map((item) => {
+      if (!isObject(item)) return null;
+      const id = typeof item.id === "string" ? item.id : "";
+      const label = typeof item.label === "string" ? item.label : id || "Attribut";
+      const inputType =
+        typeof item.input === "string"
+          ? item.input
+          : "text";
+      if (!id) return null;
+      const options = Array.isArray(item.options)
+        ? item.options.filter((value): value is string => typeof value === "string")
+        : undefined;
+      const description = typeof item.description === "string" ? item.description : undefined;
+      return {
+        id,
+        label,
+        input: inputType as AttributeType["input"],
+        options,
+        description,
+      } satisfies AttributeType;
+    })
+    .filter(Boolean) as AttributeType[];
+}
+
+function clampNumber(value: unknown, fallback: number, options?: { min?: number; max?: number }): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  const min = options?.min ?? -Infinity;
+  const max = options?.max ?? Infinity;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function normalizeLightboxSettings(input: unknown): LightboxSettings {
+  if (!isObject(input)) {
+    return { ...defaultLightbox };
+  }
+
+  return {
+    overlayColor: typeof input.overlayColor === "string" ? input.overlayColor : defaultLightbox.overlayColor,
+    overlayOpacity: clampNumber(input.overlayOpacity, defaultLightbox.overlayOpacity, { min: 0, max: 1 }),
+    overlayBlur: clampNumber(input.overlayBlur, defaultLightbox.overlayBlur, { min: 0, max: 48 }),
+    backgroundColor:
+      typeof input.backgroundColor === "string" ? input.backgroundColor : defaultLightbox.backgroundColor,
+    borderRadius: clampNumber(input.borderRadius, defaultLightbox.borderRadius, { min: 0, max: 64 }),
+    maxWidth: clampNumber(input.maxWidth, defaultLightbox.maxWidth, { min: 280, max: 1600 }),
+    padding: clampNumber(input.padding, defaultLightbox.padding, { min: 12, max: 96 }),
+  };
+}
+
+function normalizeSettings(value: unknown): SiteSettings {
+  if (!isObject(value)) {
+    return { ...defaultSettings, ui: { ...defaultSettings.ui, lightbox: { ...defaultLightbox } } };
+  }
+
+  const ui = isObject(value.ui) ? value.ui : {};
+
+  return {
+    attributeTypes: normalizeAttributeTypes(value.attributeTypes),
+    ui: {
+      theme: typeof ui.theme === "string" ? ui.theme : defaultSettings.ui.theme,
+      accentColor: typeof ui.accentColor === "string" ? ui.accentColor : defaultSettings.ui.accentColor,
+      paperColor: typeof ui.paperColor === "string" ? ui.paperColor : defaultSettings.ui.paperColor,
+      texture: typeof ui.texture === "string" ? ui.texture : undefined,
+      animation: {
+        duration: clampNumber(ui.animation && (ui.animation as UnknownRecord).duration, defaultSettings.ui.animation.duration, {
+          min: 0,
+          max: 10000,
+        }),
+        easing:
+          isObject(ui.animation) && typeof ui.animation.easing === "string"
+            ? ui.animation.easing
+            : defaultSettings.ui.animation.easing,
+      },
+      lightbox: normalizeLightboxSettings(ui.lightbox),
+    },
+  };
+}
+
+async function readSettings(): Promise<SiteSettings> {
+  try {
+    const raw = await fs.readFile(SETTINGS_FILE, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    return normalizeSettings(parsed);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ...defaultSettings, ui: { ...defaultSettings.ui, lightbox: { ...defaultLightbox } } };
+    }
+    throw error;
+  }
+}
+
+export const getSettings = cache(readSettings);

--- a/site/types/metadata.ts
+++ b/site/types/metadata.ts
@@ -1,0 +1,29 @@
+export type AttributeValue =
+  | { type: "text"; value: string }
+  | { type: "textarea"; value: string }
+  | { type: "boolean"; value: boolean }
+  | { type: "date"; value: string }
+  | { type: "number"; value: number }
+  | { type: "link"; value: { url: string; label?: string } }
+  | { type: "image"; value: string }
+  | { type: "select"; value: string }
+  | { type: "color"; value: string };
+
+export type AttributeRecord = Record<string, AttributeValue>;
+
+export type AttributeType = {
+  id: string;
+  label: string;
+  input:
+    | "text"
+    | "textarea"
+    | "checkbox"
+    | "date"
+    | "number"
+    | "link"
+    | "image"
+    | "select"
+    | "color";
+  options?: string[];
+  description?: string;
+};

--- a/storage/settings.json
+++ b/storage/settings.json
@@ -11,6 +11,15 @@
   "ui": {
     "theme": "dawn",
     "accentColor": "#8c6b4f",
-    "paperColor": "#f5ede2"
+    "paperColor": "#f5ede2",
+    "lightbox": {
+      "overlayColor": "#ffffff",
+      "overlayOpacity": 0.92,
+      "overlayBlur": 16,
+      "backgroundColor": "#f8f4ef",
+      "borderRadius": 22,
+      "maxWidth": 980,
+      "padding": 32
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement a reusable lightbox provider and styling to display enlarged media with metadata overlays
- wire gallery items and layout settings into the lightbox, including loading site settings on the frontend
- expose lightbox configuration controls in admin settings and persist defaults in backend metadata schema

## Testing
- npm --prefix backend run build
- npm --prefix admin run build
- npm --prefix site run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4a455d688322a465f9b31388ff43