### PR TITLE
docs: mettre a jour le readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Ce dépôt contient un atelier de CMS personnel complet organisé en monorepo. I
 
 ## Espaces inclus
 
-- `backend/` — serveur Node.js (Express + TypeScript) qui expose une API REST, observe le système de fichiers et gère les métadonnées JSON ainsi que la génération de miniatures.【F:backend/src/routes/api.ts†L9-L237】【F:backend/src/services/ThumbnailService.ts†L1-L139】
-- `admin/` — interface React (Vite + Material UI) offrant une administration joyeuse avec explorateur hiérarchique, éditeurs dynamiques et page de réglages. Le serveur de dev Vite est préconfiguré pour proxifier `/api` vers le backend.【F:admin/src/pages/SettingsPage.tsx†L33-L216】【F:admin/vite.config.ts†L1-L15】
-- `site/` — site public Next.js (App Router) qui construit la navigation à partir du dossier `medias/` et du fichier `.media-meta.json`, et fournit une route d'API interne pour diffuser médias et miniatures.【F:site/lib/mediaTree.ts†L1-L98】【F:site/lib/mediaMetadata.ts†L1-L39】【F:site/app/api/media/[...path]/route.ts†L1-L44】
-- `medias/` — racine des images/vidéos, directement synchronisée avec la structure disque. Chaque dossier peut contenir un `description.md` et les fichiers `.media-meta.json` générés par l'API y résident.【F:backend/src/config.ts†L10-L24】
-- `storage/` — stockage des métadonnées dossiers, des fiches médias et des réglages globaux (`.dossier-meta.json`, `.media-meta.json`, `settings.json`).【F:backend/src/config.ts†L10-L24】
-- `config/` — configuration partagée (ex. `thumbnails.json`) utilisée par le service de miniatures pour calculer les différents formats.【F:config/thumbnails.json†L1-L10】【F:backend/src/services/ThumbnailService.ts†L1-L104】
-- `thumbnails/` — dossier de sortie des miniatures générées automatiquement par le backend ; il est créé à la volée si absent.【F:backend/src/services/ThumbnailService.ts†L32-L87】
+- `backend/` — serveur Node.js (Express + TypeScript) qui expose une API REST, observe le système de fichiers et gère les métadonnées JSON ainsi que la génération de miniatures et la gestion du blog.
+- `admin/` — interface React (Vite + Material UI) offrant une administration joyeuse avec explorateur hiérarchique, éditeurs dynamiques, page de réglages et outils complets de rédaction pour le blog.
+- `site/` — site public Next.js (App Router) qui construit la navigation à partir du dossier `medias/`, fournit une route d'API interne pour diffuser médias et miniatures, affiche le blog et propose une expérience de lecture enrichie par la lightbox.
+- `medias/` — racine des images/vidéos, directement synchronisée avec la structure disque. Chaque dossier peut contenir un `description.md` et les fichiers `.media-meta.json` générés par l'API y résident.
+- `storage/` — stockage des métadonnées dossiers, des fiches médias, des réglages globaux (`.dossier-meta.json`, `.media-meta.json`, `settings.json`) ainsi que des contenus du blog.
+- `config/` — configuration partagée (ex. `thumbnails.json`) utilisée par le service de miniatures pour calculer les différents formats.
+- `thumbnails/` — dossier de sortie des miniatures générées automatiquement par le backend ; il est créé à la volée si absent.
 
-Les métadonnées sont stockées dans `storage/.dossier-meta.json`, `medias/.media-meta.json` et `storage/settings.json`. Les descriptions longues s'écrivent dans `description.md` situé dans chaque dossier média.【F:backend/src/config.ts†L16-L24】
+Les métadonnées sont stockées dans `storage/.dossier-meta.json`, `medias/.media-meta.json` et `storage/settings.json`. Les descriptions longues s'écrivent dans `description.md` situé dans chaque dossier média.
 
 ## Installation rapide
 
@@ -21,7 +21,7 @@ npm run install
 npm run dev
 ```
 
-`npm run install` installe les dépendances des trois espaces (`backend`, `admin`, `site`) et `npm run dev` lance simultanément l'API Node.js, l'interface d'administration et le site Next.js grâce à `concurrently`.【F:package.json†L5-L17】 L'API répond par défaut sur le port `4000` et l'interface admin est accessible via Vite sur le port `5173` (proxy `/api`).【F:backend/src/server.ts†L26-L36】【F:admin/vite.config.ts†L6-L15】 Pour un build de production unifié, utilisez `npm run build` depuis la racine.【F:package.json†L10-L14】
+`npm run install` installe les dépendances des trois espaces (`backend`, `admin`, `site`) et `npm run dev` lance simultanément l'API Node.js, l'interface d'administration et le site Next.js grâce à `concurrently`. L'API répond par défaut sur le port `4000` et l'interface admin est accessible via Vite sur le port `5173` (proxy `/api`). Pour un build de production unifié, utilisez `npm run build` depuis la racine.
 
 ### Installation manuelle (alternative)
 
@@ -42,46 +42,57 @@ npm install
 npm run dev
 ```
 
-Le front admin communique avec l'API via `/api/*` (proxy Vite configuré) et le site Next.js lit directement l'arborescence disque pour construire navigation et galeries. Toute modification manuelle dans `medias/` est détectée par le backend (via chokidar) et reflétée dans l'UI comme dans le site public.【F:admin/vite.config.ts†L6-L15】【F:site/lib/mediaTree.ts†L1-L98】【F:backend/src/services/ThumbnailService.ts†L1-L87】
+Le front admin communique avec l'API via `/api/*` (proxy Vite configuré) et le site Next.js lit directement l'arborescence disque pour construire navigation et galeries. Toute modification manuelle dans `medias/` est détectée par le backend (via chokidar) et reflétée dans l'UI comme dans le site public.
 
 ## Points clés
 
-- **Pas de base de données** : les métadonnées sont sérialisées dans des fichiers JSON globaux.【F:backend/src/config.ts†L16-L24】
-- **Détection d'orphelins** : un indicateur montre les fichiers sans métadonnées et inversement.【F:backend/src/routes/api.ts†L9-L237】
-- **Cache vivant** : l'arbre est mis en cache et invalidé automatiquement lors des changements disque.【F:backend/src/services/ThumbnailService.ts†L51-L116】
-- **Mode preview** : génération de tokens temporaires pour partager un média ou un dossier.【F:backend/src/routes/api.ts†L118-L179】
-- **Miniatures configurables** : le backend génère, surveille et reconstruit les miniatures selon `config/thumbnails.json`, éditable depuis l'admin.【F:config/thumbnails.json†L1-L10】【F:backend/src/services/ThumbnailService.ts†L18-L139】【F:admin/src/pages/SettingsPage.tsx†L189-L214】
-- **Site public** : Next.js exploite `medias/` et `.media-meta.json` pour proposer navigation, vignettes et diffusion des médias originaux via `/api/media/*`.【F:site/lib/mediaTree.ts†L1-L98】【F:site/lib/mediaMetadata.ts†L1-L39】【F:site/app/api/media/[...path]/route.ts†L1-L44】
+- **Pas de base de données** : les métadonnées sont sérialisées dans des fichiers JSON globaux.
+- **Détection d'orphelins** : un indicateur montre les fichiers sans métadonnées et inversement.
+- **Cache vivant** : l'arbre est mis en cache et invalidé automatiquement lors des changements disque.
+- **Mode preview** : génération de tokens temporaires pour partager un média ou un dossier.
+- **Miniatures configurables** : le backend génère, surveille et reconstruit les miniatures selon `config/thumbnails.json`, éditable depuis l'admin.
+- **Blog intégré** : création, édition, catégorisation et publication d'articles, avec import direct d'images et réglages dédiés.
+- **Lightbox immersive** : visualisation plein écran des médias sur le site public avec personnalisation fine (couleurs, rayons, tailles, blur) depuis les réglages.
+- **Site public** : Next.js exploite `medias/` et `.media-meta.json` pour proposer navigation, vignettes, diffusion des médias originaux via `/api/media/*` et mise en avant des articles du blog.
 
 ## Scripts disponibles
 
 ### Backend
-- `npm run dev` — serveur Express en mode watch (`tsx`).【F:backend/package.json†L6-L10】
-- `npm run build` — compilation TypeScript vers `dist/`.【F:backend/package.json†L6-L10】
-- `npm start` — exécute la version compilée.【F:backend/package.json†L6-L10】
+- `npm run dev` — serveur Express en mode watch (`tsx`).
+- `npm run build` — compilation TypeScript vers `dist/`.
+- `npm start` — exécute la version compilée.
 
 ### Admin
-- `npm run dev` — Vite + React en développement.【F:admin/package.json†L6-L12】
-- `npm run build` — Build de production (`tsc --noEmit` puis `vite build`).【F:admin/package.json†L6-L12】
-- `npm run preview` — Aperçu du build.【F:admin/package.json†L6-L12】
+- `npm run dev` — Vite + React en développement.
+- `npm run build` — Build de production (`tsc --noEmit` puis `vite build`).
+- `npm run preview` — Aperçu du build.
 
 ### Site
-- `npm run dev` — Next.js en mode développement (App Router).【F:site/package.json†L6-L14】
-- `npm run build` — Build de production Next.js.【F:site/package.json†L6-L14】
-- `npm run start` — Lancement du build en mode production.【F:site/package.json†L6-L14】
-- `npm run lint` — Vérification ESLint dédiée au site.【F:site/package.json†L6-L14】
+- `npm run dev` — Next.js en mode développement (App Router).
+- `npm run build` — Build de production Next.js.
+- `npm run start` — Lancement du build en mode production.
+- `npm run lint` — Vérification ESLint dédiée au site.
 
 ## Arbre API (extraits)
 
-- `GET /api/tree` — arborescence complète fusionnant fichiers et métadonnées.【F:backend/src/routes/api.ts†L33-L70】
-- `GET /api/folders?path=…` — dossier précis (avec `description.md` si présent).【F:backend/src/routes/api.ts†L71-L117】
-- `PUT /api/folders/meta` — mise à jour des métadonnées dossier.【F:backend/src/routes/api.ts†L180-L210】
-- `PUT /api/folders/description` — écriture de `description.md`.【F:backend/src/routes/api.ts†L86-L117】
-- `POST /api/medias/move` — déplacement d'un média.【F:backend/src/routes/api.ts†L211-L237】
-- `GET /api/orphans` — liste des fichiers/métadonnées orphelins.【F:backend/src/routes/api.ts†L9-L70】
-- `GET /api/thumbnails` — consultation de la configuration actuelle des miniatures.【F:backend/src/routes/api.ts†L217-L237】
-- `POST /api/thumbnails/rebuild` — régénération complète des miniatures.【F:backend/src/routes/api.ts†L217-L237】
-- `GET /api/sitemap?baseUrl=…` — génération sitemap XML.【F:backend/src/routes/api.ts†L33-L117】
+- `GET /api/tree` — arborescence complète fusionnant fichiers et métadonnées.
+- `GET /api/folders?path=…` — dossier précis (avec `description.md` si présent).
+- `PUT /api/folders/meta` — mise à jour des métadonnées dossier.
+- `PUT /api/folders/description` — écriture de `description.md`.
+- `POST /api/medias/move` — déplacement d'un média.
+- `GET /api/orphans` — liste des fichiers/métadonnées orphelins.
+- `GET /api/thumbnails` — consultation de la configuration actuelle des miniatures.
+- `POST /api/thumbnails/rebuild` — régénération complète des miniatures.
+- `GET /api/sitemap?baseUrl=…` — génération sitemap XML.
+- `GET /api/blog/articles` — liste des articles de blog et de leurs métadonnées.
+- `GET /api/blog/articles/:slug` — récupération d'un article précis.
+- `POST /api/blog/articles` — création d'un article avec upload direct des images.
+- `PUT /api/blog/articles/:slug` — mise à jour d'un article existant.
+- `DELETE /api/blog/articles/:slug` — suppression d'un article.
+- `POST /api/blog/images` — import d'une image pour le blog.
+- `GET /api/blog/settings` — consultation des réglages du blog.
+- `PUT /api/blog/settings` — mise à jour des réglages du blog.
+- `POST /api/blog/email` — création automatisée d'article à partir d'un email (Mailgun).
 
 ## Structure par défaut
 
@@ -96,7 +107,7 @@ Ces dossiers ne contiennent qu'un fichier `.gitkeep` et peuvent être remplis av
 
 ## Variables d'environnement utiles
 
-Le backend accepte plusieurs variables pour adapter chemins et comportement : `MEDIA_ROOT`, `METADATA_ROOT`, `THUMBNAILS_ROOT`, `THUMBNAIL_CONFIG_FILE`, `CACHE_TTL`, `PREVIEW_SECRET` ou encore `PORT`. Toutes disposent de valeurs par défaut pointant vers ce dépôt.【F:backend/src/config.ts†L10-L33】
+Le backend accepte plusieurs variables pour adapter chemins et comportement : `MEDIA_ROOT`, `METADATA_ROOT`, `THUMBNAILS_ROOT`, `THUMBNAIL_CONFIG_FILE`, `CACHE_TTL`, `PREVIEW_SECRET` ou encore `PORT`. Toutes disposent de valeurs par défaut pointant vers ce dépôt.
 
 ---
 


### PR DESCRIPTION
## Summary
- moderniser la section "Espaces inclus" en intégrant les nouveautés blog et lightbox
- enrichir la liste des points clés avec les fonctionnalités blog et lightbox
- retirer toutes les références de fichiers/lignes et détailler les endpoints du blog dans l’API

## Testing
- non pertinent (modifications de documentation uniquement)

------
https://chatgpt.com/codex/tasks/task_e_68cdaa8179048322abf38ba72b5cc740