### PR TITLE
Add remember me option to admin login

### DIFF
--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -176,8 +176,8 @@ export const api = {
     await mutate('/api/blog/settings');
     return response as BlogSettings;
   },
-  async login(password: string) {
-    await postJson('/api/auth/login', { password });
+  async login(password: string, remember: boolean = false) {
+    await postJson('/api/auth/login', { password, remember });
     await mutate('/api/auth/session');
   },
   async logout() {

--- a/admin/src/pages/LoginPage.tsx
+++ b/admin/src/pages/LoginPage.tsx
@@ -3,9 +3,11 @@ import {
   Alert,
   Box,
   Button,
+  Checkbox,
   Card,
   CardContent,
   CircularProgress,
+  FormControlLabel,
   Stack,
   TextField,
   Typography
@@ -19,6 +21,7 @@ interface Props {
 
 export const LoginPage: React.FC<Props> = ({ onSuccess }) => {
   const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,8 +34,9 @@ export const LoginPage: React.FC<Props> = ({ onSuccess }) => {
     setLoading(true);
     setError(null);
     try {
-      await api.login(password);
+      await api.login(password, rememberMe);
       setPassword('');
+      setRememberMe(false);
       onSuccess();
     } catch (err) {
       setError((err as Error).message || 'Authentification impossible');
@@ -73,6 +77,16 @@ export const LoginPage: React.FC<Props> = ({ onSuccess }) => {
                   onChange={(event) => setPassword(event.target.value)}
                   autoFocus
                   fullWidth
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={rememberMe}
+                      onChange={(event) => setRememberMe(event.target.checked)}
+                      color="primary"
+                    />
+                  }
+                  label="Rester connecté une semaine"
                 />
                 <Button
                   type="submit"

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -6,18 +6,20 @@ import { getSessionTokenFromRequest, requireAuth } from '../middleware/auth.js';
 const router = Router();
 
 const loginSchema = z.object({
-  password: z.string().min(1)
+  password: z.string().min(1),
+  remember: z.boolean().optional()
 });
 
 router.post('/login', async (req, res, next) => {
   try {
-    const { password } = loginSchema.parse(req.body ?? {});
+    const { password, remember } = loginSchema.parse(req.body ?? {});
     const valid = await authService.verifyPassword(password);
     if (!valid) {
       res.status(401).send('Mot de passe invalide');
       return;
     }
-    authService.issueSession(res);
+    const duration = remember ? authService.extendedSessionDurationMs : undefined;
+    authService.issueSession(res, duration);
     res.json({ success: true });
   } catch (error) {
     next(error);


### PR DESCRIPTION
## Summary
- allow the auth service to issue longer sessions and honor a remember-me flag
- expose a "rester connecté" checkbox in the admin login form and send the preference to the backend

## Testing
- npm run build (backend)
- npm run build (admin)

------
https://chatgpt.com/codex/tasks/task_e_68cfec2aae4c8322817dac1e4ca6fcaa