### PR TITLE
Improve media grid drag interactions

### DIFF
--- a/admin/src/components/MediaGrid.tsx
+++ b/admin/src/components/MediaGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Card, CardActionArea, CardContent, Chip, Stack, Typography } from '@mui/material';
 import { MediaNode } from '../api/types.js';
 import ImageIcon from '@mui/icons-material/ImageRounded';
@@ -19,43 +19,85 @@ export const MediaGrid: React.FC<Props> = ({ medias, selectedPath, onSelect, onR
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
   const [tailActive, setTailActive] = useState(false);
-  const [localOrder, setLocalOrder] = useState<string[] | null>(null);
+  const [previewOrder, setPreviewOrder] = useState<string[] | null>(null);
+  const committedOrderRef = useRef<string[]>([]);
 
   useEffect(() => {
-    setLocalOrder(null);
+    committedOrderRef.current = medias.map((media) => media.path);
+    setPreviewOrder(null);
     setDraggingId(null);
     setDragOverId(null);
     setTailActive(false);
   }, [medias]);
 
+  const baseOrder = useMemo(() => medias.map((media) => media.path), [medias]);
+
   const orderedMedias = useMemo(() => {
-    if (!localOrder) return medias;
+    if (!previewOrder) return medias;
     const map = new Map(medias.map((media) => [media.path, media]));
     const arranged: MediaNode[] = [];
-    localOrder.forEach((path) => {
+    previewOrder.forEach((path) => {
       const media = map.get(path);
       if (media) arranged.push(media);
     });
     medias.forEach((media) => {
-      if (!localOrder.includes(media.path)) {
+      if (!previewOrder.includes(media.path)) {
         arranged.push(media);
       }
     });
     return arranged;
-  }, [localOrder, medias]);
+  }, [previewOrder, medias]);
 
   const mediaPaths = useMemo(() => orderedMedias.map((media) => media.path), [orderedMedias]);
+
+  const updatePreviewOrder = (nextOrder: string[]) => {
+    setPreviewOrder((current) => {
+      if (current) {
+        return isSameOrder(current, nextOrder) ? current : nextOrder;
+      }
+      return isSameOrder(baseOrder, nextOrder) ? current : nextOrder;
+    });
+  };
+
+  const previewReorderTo = (targetId: string) => {
+    if (!draggingId || draggingId === targetId) return;
+    const currentOrder = previewOrder ?? baseOrder;
+    const fromIndex = currentOrder.indexOf(draggingId);
+    const toIndex = currentOrder.indexOf(targetId);
+    if (fromIndex === -1 || toIndex === -1) return;
+    const nextOrder = [...currentOrder];
+    nextOrder.splice(fromIndex, 1);
+    nextOrder.splice(toIndex, 0, draggingId);
+    updatePreviewOrder(nextOrder);
+  };
+
+  const previewMoveToEnd = () => {
+    if (!draggingId) return;
+    const currentOrder = previewOrder ?? baseOrder;
+    const fromIndex = currentOrder.indexOf(draggingId);
+    if (fromIndex === -1 || fromIndex === currentOrder.length - 1) return;
+    const nextOrder = [...currentOrder];
+    nextOrder.splice(fromIndex, 1);
+    nextOrder.push(draggingId);
+    updatePreviewOrder(nextOrder);
+  };
 
   const isMediaDrag = (event: React.DragEvent) =>
     Array.from(event.dataTransfer?.types ?? []).includes(MEDIA_DRAG_TYPE);
 
-  const handleReorder = (nextOrder: string[]) => {
-    if (isSameOrder(nextOrder, mediaPaths)) return;
-    setLocalOrder(nextOrder);
+  const commitOrder = (nextOrder: string[]) => {
+    if (isSameOrder(nextOrder, committedOrderRef.current)) {
+      return;
+    }
+    setPreviewOrder(nextOrder);
+    committedOrderRef.current = nextOrder;
     onReorder(nextOrder);
   };
 
-  const handleDragEnd = () => {
+  const handleDragEnd = (event: React.DragEvent<HTMLDivElement>) => {
+    if (event.dataTransfer.dropEffect === 'none') {
+      setPreviewOrder(null);
+    }
     setDraggingId(null);
     setDragOverId(null);
     setTailActive(false);
@@ -91,6 +133,11 @@ export const MediaGrid: React.FC<Props> = ({ medias, selectedPath, onSelect, onR
               event.dataTransfer.effectAllowed = 'move';
               event.dataTransfer.setData(MEDIA_DRAG_TYPE, media.path);
               event.dataTransfer.setData('text/plain', media.path);
+              const node = event.currentTarget;
+              const rect = node.getBoundingClientRect();
+              if (event.dataTransfer.setDragImage) {
+                event.dataTransfer.setDragImage(node, rect.width / 2, rect.height / 2);
+              }
             }}
             onDragOver={(event: React.DragEvent<HTMLDivElement>) => {
               if (!isMediaDrag(event) || !draggingId || draggingId === media.path) return;
@@ -99,6 +146,7 @@ export const MediaGrid: React.FC<Props> = ({ medias, selectedPath, onSelect, onR
               event.dataTransfer.dropEffect = 'move';
               setDragOverId(media.path);
               setTailActive(false);
+              previewReorderTo(media.path);
             }}
             onDragEnter={(event: React.DragEvent<HTMLDivElement>) => {
               if (!isMediaDrag(event) || !draggingId || draggingId === media.path) return;
@@ -106,6 +154,7 @@ export const MediaGrid: React.FC<Props> = ({ medias, selectedPath, onSelect, onR
               event.stopPropagation();
               setDragOverId(media.path);
               setTailActive(false);
+              previewReorderTo(media.path);
             }}
             onDragLeave={(event: React.DragEvent<HTMLDivElement>) => {
               if (!isMediaDrag(event)) return;
@@ -121,13 +170,8 @@ export const MediaGrid: React.FC<Props> = ({ medias, selectedPath, onSelect, onR
               setDragOverId(null);
               setTailActive(false);
               if (draggingId === media.path) return;
-              const fromIndex = mediaPaths.indexOf(draggingId);
-              const toIndex = mediaPaths.indexOf(media.path);
-              if (fromIndex === -1 || toIndex === -1 || fromIndex === toIndex) return;
-              const nextOrder = [...mediaPaths];
-              nextOrder.splice(fromIndex, 1);
-              nextOrder.splice(toIndex, 0, draggingId);
-              handleReorder(nextOrder);
+              const finalOrder = previewOrder ?? mediaPaths;
+              commitOrder(finalOrder);
             }}
             onDragEnd={handleDragEnd}
             sx={{
@@ -198,18 +242,15 @@ export const MediaGrid: React.FC<Props> = ({ medias, selectedPath, onSelect, onR
           event.dataTransfer.dropEffect = 'move';
           setDragOverId(null);
           setTailActive(true);
+          previewMoveToEnd();
         }}
         onDrop={(event: React.DragEvent<HTMLDivElement>) => {
           if (!isMediaDrag(event) || !draggingId) return;
           event.preventDefault();
           event.stopPropagation();
           setTailActive(false);
-          const fromIndex = mediaPaths.indexOf(draggingId);
-          if (fromIndex === -1 || fromIndex === mediaPaths.length - 1) return;
-          const nextOrder = [...mediaPaths];
-          nextOrder.splice(fromIndex, 1);
-          nextOrder.push(draggingId);
-          handleReorder(nextOrder);
+          const finalOrder = previewOrder ?? mediaPaths;
+          commitOrder(finalOrder);
         }}
         onDragLeave={(event: React.DragEvent<HTMLDivElement>) => {
           if (!isMediaDrag(event)) return;


### PR DESCRIPTION
## Summary
- preview media order locally during drag and drop so surrounding thumbnails shift out of the way
- keep track of committed order to avoid redundant updates and restore state when drops are cancelled
- use the card itself as the drag image so the whole tile follows the cursor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00c5712748322ac3b0500d2430ae9