### PR TITLE
Fix drop handler when preview reorders dragging tile

### DIFF
--- a/admin/src/components/MediaGrid.tsx
+++ b/admin/src/components/MediaGrid.tsx
@@ -540,8 +540,11 @@ export const MediaGrid: React.FC<Props> = ({
               event.stopPropagation();
               setDragOverId(null);
               setTailActive(false);
-              if (draggingId === media.path) return;
               const finalOrder = previewOrder ?? mediaPaths;
+              if (draggingId === media.path && isSameOrder(finalOrder, committedOrderRef.current)) {
+                dropHandledRef.current = true;
+                return;
+              }
               dropHandledRef.current = true;
               commitOrder(finalOrder);
             }}


### PR DESCRIPTION
## Summary
- allow tile drop handlers to commit the previewed order even when the hovered tile becomes the dragged item
- keep skipping commits when the order has not changed while still marking the drop as handled

## Testing
- npm run lint -- --version *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d4336d464c8322baeb83580da069e5