### PR TITLE
Refactor thumbnail storage to use stable media IDs

### DIFF
--- a/backend/src/types/metadata.ts
+++ b/backend/src/types/metadata.ts
@@ -54,6 +54,7 @@ export const mediaThumbnailSchema = z.object({
 });
 
 export const mediaMetadataSchema = z.object({
+  id: z.string().uuid().optional(),
   title: z.string().optional(),
   description: z.string().optional(),
   tags: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- assign persistent UUIDs to media metadata and generate thumbnails using preset folders keyed by ID
- delete outdated thumbnails based on recorded paths and keep metadata when files are renamed or moved
- simplify rename logic since thumbnail paths no longer depend on media file locations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5902677bc8322b05474761f45252a